### PR TITLE
Add simple terminal overlay

### DIFF
--- a/about.html
+++ b/about.html
@@ -40,7 +40,8 @@
 
         <h3>Education</h3>
         <p>B.Sc. Computer Science — University of Calgary (Sep 2020 – Apr 2025)</p>
-      </article>
-    </main>
+  </article>
+  </main>
+  <script src="assets/js/terminal.js"></script>
   </body>
 </html>

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -189,3 +189,38 @@ a:hover    { color: #FF0000; text-decoration: underline; }
   text-decoration: underline;
 }
 
+
+/* ────────────────────────────────────────── */
+/* terminal overlay                          */
+/* ────────────────────────────────────────── */
+#terminal-overlay {
+  display: none;
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  width: 100%;
+  height: 40%;
+  background: rgba(0,0,0,0.9);
+  color: #00FF00;
+  font-family: "Courier New", Courier, monospace;
+  padding: 8px;
+  overflow-y: auto;
+  z-index: 9999;
+}
+
+#terminal-overlay input {
+  width: 100%;
+  background: transparent;
+  border: none;
+  color: inherit;
+  font: inherit;
+  outline: none;
+}
+
+#terminalLink {
+  position: fixed;
+  bottom: 4px;
+  right: 8px;
+  font-family: "Courier New", Courier, monospace;
+  font-size: 0.8rem;
+}

--- a/assets/js/terminal.js
+++ b/assets/js/terminal.js
@@ -1,0 +1,78 @@
+(function() {
+  const overlay = document.createElement('div');
+  overlay.id = 'terminal-overlay';
+  overlay.innerHTML = '<div id="terminal-output"></div><input id="terminal-input" type="text" autocomplete="off" />';
+  document.body.appendChild(overlay);
+
+  const output = overlay.querySelector('#terminal-output');
+  const input = overlay.querySelector('#terminal-input');
+
+  const quotes = [
+    'Talk is cheap. Show me the code. – Linus Torvalds',
+    'Premature optimization is the root of all evil. – Donald Knuth',
+    'Programs must be written for people to read. – Harold Abelson'
+  ];
+
+  const commands = {
+    help() {
+      print('Commands: help, quote, clear');
+    },
+    quote() {
+      const q = quotes[Math.floor(Math.random() * quotes.length)];
+      print(q);
+    },
+    clear() {
+      output.innerHTML = '';
+    }
+  };
+
+  function print(text) {
+    const div = document.createElement('div');
+    div.textContent = text;
+    output.appendChild(div);
+    output.scrollTop = output.scrollHeight;
+  }
+
+  function toggle() {
+    if (overlay.style.display === 'block') {
+      overlay.style.display = 'none';
+    } else {
+      overlay.style.display = 'block';
+      input.focus();
+    }
+  }
+
+  document.addEventListener('keydown', function(e) {
+    if (e.key === '~' && !/input|textarea/i.test(e.target.tagName)) {
+      e.preventDefault();
+      toggle();
+    }
+  });
+
+  input.addEventListener('keydown', function(e) {
+    if (e.key === 'Enter') {
+      const cmd = input.value.trim();
+      if (cmd) {
+        print('> ' + cmd);
+        if (commands[cmd]) {
+          commands[cmd]();
+        } else {
+          print('Unknown command');
+        }
+      }
+      input.value = '';
+    } else if (e.key === 'Escape') {
+      toggle();
+    }
+  });
+
+  const link = document.createElement('a');
+  link.id = 'terminalLink';
+  link.href = '#';
+  link.textContent = 'Terminal';
+  link.addEventListener('click', function(e) {
+    e.preventDefault();
+    toggle();
+  });
+  document.body.appendChild(link);
+})();

--- a/index.html
+++ b/index.html
@@ -124,5 +124,6 @@
   <script src="assets/js/lavaOrb.js"></script>
   <script src="assets/js/keypad.js"></script>
   <script src="assets/js/mobileCTA.js"></script>
+  <script src="assets/js/terminal.js"></script>
 </body>
 </html>

--- a/pages/classified-archive.html
+++ b/pages/classified-archive.html
@@ -102,11 +102,12 @@
          href="https://www.youtube.com/watch?v=O7FIiYsVy3U"
          target="_blank" rel="noopener">
         ▶ May I Have Some Oats, Brother?
-      </a>
-    </p>
+</a>
+</p>
 
-    <a class="return" href="/index.html">← Return to Surface World</a>
-    <div class="crystal" aria-hidden="true"></div>
-  </div>
+<a class="return" href="/index.html">← Return to Surface World</a>
+<div class="crystal" aria-hidden="true"></div>
+</div>
+<script src="../assets/js/terminal.js"></script>
 </body>
 </html>

--- a/posts/ai-mistakes-internship-apps.html
+++ b/posts/ai-mistakes-internship-apps.html
@@ -32,4 +32,5 @@
 <p>#cs  #chatGPT  #AI</p>
 </article></main>
 </body>
+<script src="../assets/js/terminal.js"></script>
 </html>

--- a/posts/deploying-python-apps-databricks.html
+++ b/posts/deploying-python-apps-databricks.html
@@ -57,4 +57,5 @@
       </article>
     </main>
   </body>
+  <script src="../assets/js/terminal.js"></script>
 </html>

--- a/posts/internships-hard-to-get.html
+++ b/posts/internships-hard-to-get.html
@@ -28,4 +28,5 @@
 <p>#internship  #ComputerScience  #advice</p>
 </article></main>
 </body>
+<script src="../assets/js/terminal.js"></script>
 </html>

--- a/posts/killing-it-in-cs-part-2.html
+++ b/posts/killing-it-in-cs-part-2.html
@@ -30,4 +30,5 @@
 <p>#CS  #Uni  #Advice</p>
 </article></main>
 </body>
+<script src="../assets/js/terminal.js"></script>
 </html>

--- a/posts/pacesetter-launch.html
+++ b/posts/pacesetter-launch.html
@@ -60,4 +60,5 @@
     </article>
   </main>
 </body>
+<script src="../assets/js/terminal.js"></script>
 </html>

--- a/posts/three-best-strategies-cs-degree.html
+++ b/posts/three-best-strategies-cs-degree.html
@@ -33,4 +33,5 @@
 <p>If you have more good ones, send them my way :)</p>
 </article></main>
 </body>
+<script src="../assets/js/terminal.js"></script>
 </html>


### PR DESCRIPTION
## Summary
- add new terminal.js for a 90s-style pop up terminal
- style terminal overlay in style.css
- include the script on all pages

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6840592d82cc833283914bbbb535120b