### PR TITLE
Improve secret archive keypad

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -189,6 +189,40 @@ a:hover    { color: #FF0000; text-decoration: underline; }
   text-decoration: underline;
 }
 
+/* keypad styles for the secret archive */
+#keypad {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+  margin-top: 4px;
+}
+
+#keypad button {
+  width: 32px;
+  height: 32px;
+  padding: 0;
+  font-family: "Courier New", monospace;
+  font-size: 1rem;
+  background: #C0C0C0;
+  border: 2px outset #FFFFFF;
+  cursor: pointer;
+}
+
+#keypad button:active {
+  border-style: inset;
+}
+
+#codeDisplay {
+  margin-top: 4px;
+  padding: 4px;
+  min-height: 24px;
+  background: #000;
+  color: #00FF00;
+  border: 2px inset #FFFFFF;
+  font-family: "Courier New", monospace;
+  font-size: 1rem;
+}
+
 
 /* ────────────────────────────────────────── */
 /* terminal overlay                          */


### PR DESCRIPTION
## Summary
- style the keypad under "Classified Archive" to match the 90s theme

## Testing
- `python scripts/check_links.py`


------
https://chatgpt.com/codex/tasks/task_e_68405c8dab78833288216bec4c597bd6