### PR TITLE
Add Open Graph metadata

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,6 +5,9 @@
   <title>Caleb Fedyshen • Blog</title>
   <meta name="viewport" content="width=device-width,initial-scale=1">
   <link rel="stylesheet" href="assets/css/style.css">
+  <meta property="og:title" content="Caleb Fedyshen • Blog">
+  <meta property="og:description" content="Musings on software, data engineering and life.">
+  <meta property="og:image" content="assets/images/starfield.gif">
 
   <!-- Lava-lamp shaders -->
   <script id="vertexShader"   type="x-shader/x-vertex">

--- a/posts/ai-mistakes-internship-apps.html
+++ b/posts/ai-mistakes-internship-apps.html
@@ -5,6 +5,9 @@
   <title>The Worst Ways to Use AI in Internship / Job Applications</title>
   <meta name="viewport" content="width=device-width,initial-scale=1">
   <link rel="stylesheet" href="../assets/css/style.css">
+  <meta property="og:title" content="The Worst Ways to Use AI in Internship / Job Applications">
+  <meta property="og:description" content="Common ChatGPT pitfalls that sabotage applications and how to avoid them.">
+  <meta property="og:image" content="../assets/images/Screenshot 2025-05-05 115533.png">
 </head>
 <body>
 <header>

--- a/posts/deploying-python-apps-databricks.html
+++ b/posts/deploying-python-apps-databricks.html
@@ -5,6 +5,9 @@
     <title>Deploying Python Apps on Databricks: What No One Tells You</title>
     <meta name="viewport" content="width=device-width,initial-scale=1">
     <link rel="stylesheet" href="../assets/css/style.css">
+    <meta property="og:title" content="Deploying Python Apps on Databricks: What No One Tells You">
+    <meta property="og:description" content="Hard-won tips from launching Flask and Streamlit apps on Databricks.">
+    <meta property="og:image" content="../assets/images/Screenshot 2025-05-05 115437.png">
   </head>
   <body>
     <header>

--- a/posts/internships-hard-to-get.html
+++ b/posts/internships-hard-to-get.html
@@ -5,6 +5,9 @@
   <title>Internships Are Hard to Get – First Tips</title>
   <meta name="viewport" content="width=device-width,initial-scale=1">
   <link rel="stylesheet" href="../assets/css/style.css">
+  <meta property="og:title" content="Internships Are Hard to Get – First Tips">
+  <meta property="og:description" content="Initial advice for landing that elusive internship.">
+  <meta property="og:image" content="../assets/images/wizard-staff.png">
 </head>
 <body>
 <header>

--- a/posts/killing-it-in-cs-part-2.html
+++ b/posts/killing-it-in-cs-part-2.html
@@ -5,6 +5,9 @@
   <title>Killing it in Computer Science (and other disciplines) — Part 2</title>
   <meta name="viewport" content="width=device-width,initial-scale=1">
   <link rel="stylesheet" href="../assets/css/style.css">
+  <meta property="og:title" content="Killing it in Computer Science (and other disciplines) — Part 2">
+  <meta property="og:description" content="Continuing the series with tips for succeeding in group projects and classes.">
+  <meta property="og:image" content="../assets/images/wizard-staff.png">
 </head>
 <body>
 <header>

--- a/posts/pacesetter-launch.html
+++ b/posts/pacesetter-launch.html
@@ -5,6 +5,9 @@
   <title>Launching the Plains Pacesetter Step Challenge</title>
   <meta name="viewport" content="width=device-width,initial-scale=1">
   <link rel="stylesheet" href="../assets/css/style.css">
+  <meta property="og:title" content="Launching the Plains Pacesetter Step Challenge">
+  <meta property="og:description" content="A behind-the-scenes look at building the Pacesetter step challenge.">
+  <meta property="og:image" content="../assets/images/pacesetter_architecture.png">
 </head>
 <body>
   <header>

--- a/posts/three-best-strategies-cs-degree.html
+++ b/posts/three-best-strategies-cs-degree.html
@@ -5,6 +5,9 @@
   <title>The Three Best Strategies for Killing a CS Degree</title>
   <meta name="viewport" content="width=device-width,initial-scale=1">
   <link rel="stylesheet" href="../assets/css/style.css">
+  <meta property="og:title" content="The Three Best Strategies for Killing a CS Degree">
+  <meta property="og:description" content="Advice on excelling in your computer science studies and future career.">
+  <meta property="og:image" content="../assets/images/wizard-staff.png">
 </head>
 <body>
 <header>


### PR DESCRIPTION
## Summary
- enhance SEO and sharing with Open Graph meta tags on homepage and posts
- reference screenshots and images for `og:image`

## Testing
- `python3 scripts/check_links.py`

------
https://chatgpt.com/codex/tasks/task_e_68405c1e0edc833299d4d42618414b07