### PR TITLE
Fix terminal overlay focus and auto-scrolling

### DIFF
--- a/assets/js/terminal.js
+++ b/assets/js/terminal.js
@@ -101,7 +101,7 @@
     output.appendChild(div);
     // wait for the DOM to update before scrolling
     setTimeout(() => {
-      output.scrollTop = output.scrollHeight;
+      overlay.scrollTop = overlay.scrollHeight;
     }, 0);
   }
 
@@ -110,6 +110,7 @@
     if (shouldShow) {
       overlay.style.display = 'block';
       localStorage.setItem('terminal-open', 'true');
+      overlay.scrollTop = overlay.scrollHeight;
       input.focus();
     } else {
       overlay.style.display = 'none';
@@ -117,7 +118,7 @@
     }
   }
 
-  overlay.addEventListener('mousedown', function() {
+  overlay.addEventListener('click', function() {
     input.focus();
   });
 


### PR DESCRIPTION
## Summary
- ensure clicking anywhere in the terminal overlay focuses the input
- keep the overlay scrolled to the bottom when new output arrives or when opening

## Testing
- `python3 scripts/check_links.py`

------
https://chatgpt.com/codex/tasks/task_e_68407dbb5da88332a2fac721c768f26d