### PR TITLE
Remove terminal screenshot

### DIFF
--- a/index.html
+++ b/index.html
@@ -85,6 +85,7 @@
     <main class="main-column">
       <h2>Blog Posts</h2>
       <ul>
+        <li><time datetime="2025-06-04">4 Jun 2025</time> <a href="posts/codex-agentic-programming.html">Codex Builds My Blog a Terminal</a></li>
         <li><time datetime="2025-05-05">5 May 2025</time> <a href="posts/pacesetter-launch.html">Launching the Plains Pacesetter Step Challenge</a></li>
         <li><time datetime="2025-04-30">30 Apr 2025</time> <a href="posts/deploying-python-apps-databricks.html">Deploying Python Apps on Databricks: What No One Tells You</a></li>
         <li><time datetime="2024-11-30">30 Nov 2024</time> <a href="posts/killing-it-in-cs-part-2.html">Killing It in Computer Science (Part 2)</a></li>

--- a/posts/codex-agentic-programming.html
+++ b/posts/codex-agentic-programming.html
@@ -1,0 +1,31 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Codex Builds My Blog a Terminal</title>
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <link rel="stylesheet" href="../assets/css/style.css">
+  <meta property="og:title" content="Codex Builds My Blog a Terminal">
+  <meta property="og:description" content="How OpenAI's Codex quietly upgraded my site with a terminal emulator.">
+  <meta property="og:image" content="../assets/images/terminal.png">
+</head>
+<body>
+<header>
+  <h1>Codex Builds My Blog a Terminal</h1>
+  <nav><a href="../index.html">Home</a>  <a href="../about.html">About Me</a></nav>
+</header>
+
+<main><article>
+<p><em>4 Jun 2025 • Calgary, AB</em></p>
+
+<p>Open AI's Codex agentic programming system has been adding features to my blog in the background today, while I work on… well my actual work. My blog now has a terminal emulator built in that lets you navigate the site and get a fortune told, among other functions.</p>
+
+<p><img src="../assets/images/terminal.png" alt="Blog terminal screenshot"></p>
+
+<p>So far Codex has done almost all the work. I know it seems scary for some people, but to me the best path is to learn every new technology quickly and use it as a force multiplier. Codex still shares the base model's limitations on complex problems but can carry out tasks on its own. It will only get better from here — I'm already feeling the AGI lol.</p>
+
+<p>#codex #AI #automation</p>
+</article></main>
+</body>
+<script src="../assets/js/terminal.js"></script>
+</html>


### PR DESCRIPTION
## Summary
- keep the new Codex terminal blog post and index link
- remove the binary screenshot so the user can add it later

## Testing
- `python3 scripts/check_links.py` *(fails: posts/codex-agentic-programming.html missing ../assets/images/terminal.png)*

------
https://chatgpt.com/codex/tasks/task_e_68408967e5848332aa1ca4ac6f3e3414