### PR TITLE
Hide Terminal on Mobile

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -258,3 +258,11 @@ a:hover    { color: #FF0000; text-decoration: underline; }
   font-family: "Courier New", Courier, monospace;
   font-size: 0.8rem;
 }
+
+/* Hide terminal overlay and link on small screens */
+@media (max-width: 600px) {
+  #terminal-overlay,
+  #terminalLink {
+    display: none !important;
+  }
+}


### PR DESCRIPTION
## Summary
- prevent terminal overlay and link from appearing on narrow screens

## Testing
- `python3 scripts/check_links.py`

------
https://chatgpt.com/codex/tasks/task_e_68409d30dcd0833293f7a0424a81c593