### PR TITLE
Fix mobile layout spacing and hide Linux badge

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -149,10 +149,12 @@ a          { color: #0000EE; }
 
   .main-column {
     order: 1;
+    flex: 0 0 auto;
   }
 
   .reading-sidebar {
     order: 2;
+    flex: 0 0 auto;
   }
 }
 
@@ -264,5 +266,8 @@ a:hover    { color: #FF0000; text-decoration: underline; }
   #terminal-overlay,
   #terminalLink {
     display: none !important;
+  }
+  .buttons88x31 .linux-button {
+    display: none;
   }
 }

--- a/index.html
+++ b/index.html
@@ -94,9 +94,9 @@
         <li><time datetime="2024-11-15">15 Nov 2024</time> <a href="posts/three-best-strategies-cs-degree.html">Three Strategies for Killing a CS Degree</a></li>
       </ul>
 
-      <div class="buttons88x31" align="center">
-        <img src="https://raw.githubusercontent.com/vilgacx/88x31/main/gifs/html3.gif" alt="HTML Power">
-        <img src="https://raw.githubusercontent.com/vilgacx/88x31/main/gifs/linux_powered.gif" alt="Linux Powered">
+        <div class="buttons88x31" align="center">
+          <img src="https://raw.githubusercontent.com/vilgacx/88x31/main/gifs/html3.gif" alt="HTML Power">
+          <img class="linux-button" src="https://raw.githubusercontent.com/vilgacx/88x31/main/gifs/linux_powered.gif" alt="Linux Powered">
         <a href="https://oyster-app-qu3oz.ondigitalocean.app/" target="_blank" rel="noopener">
           <img src="https://raw.githubusercontent.com/vilgacx/88x31/main/gifs/click_here.gif" alt="Click Here">
         </a>


### PR DESCRIPTION
## Summary
- tune mobile flex settings so `.main-column` height doesn't overshoot its content
- hide the Linux Powered badge on narrow screens
- add `.linux-button` class in markup for targeting

## Testing
- `tidy -e index.html`

------
https://chatgpt.com/codex/tasks/task_e_6840a0b70d508332bf665971a08f7448