### PR TITLE
Add terminal commands for marquee text

### DIFF
--- a/assets/js/terminal.js
+++ b/assets/js/terminal.js
@@ -6,6 +6,12 @@
 
   const output = overlay.querySelector('#terminal-output');
   const input = overlay.querySelector('#terminal-input');
+  const marquee = document.querySelector('marquee');
+  const textFiles = ['bee-movie.txt'];
+
+  if (marquee) {
+    marquee.scrollAmount = 100;
+  }
 
   const quotes = [
     'You cannot steer a ship thats not moving.',
@@ -20,7 +26,11 @@
 
   const commands = {
     help() {
-      print('Commands: help, quote, clear, ls, cd <link>, pwd, date, whoami, echo <text>, fortune, exit');
+      let base = 'Commands: help, quote, clear, ls, cd <link>, pwd, date, whoami, echo <text>, fortune, exit';
+      if (marquee) {
+        base += ', cat [file], speed <amount>';
+      }
+      print(base);
     },
     quote() {
       const q = quotes[Math.floor(Math.random() * quotes.length)];
@@ -79,12 +89,47 @@
       print('................||----w.||');
       print('................||......||');
     },
+    cat(file) {
+      if (!marquee) {
+        print('This command is only available on the index page.');
+        return;
+      }
+      if (!file) {
+        print('Available files: ' + textFiles.join(' '));
+        return;
+      }
+      const fname = file.endsWith('.txt') ? file : file + '.txt';
+      fetch('assets/text/' + fname)
+        .then(r => r.ok ? r.text() : Promise.reject())
+        .then(text => {
+          marquee.textContent = text;
+        })
+        .catch(() => {
+          print('No such file');
+        });
+    },
+    speed(val) {
+      if (!marquee) {
+        print('This command is only available on the index page.');
+        return;
+      }
+      const n = parseInt(val, 10);
+      if (isNaN(n)) {
+        print('Usage: speed <number>');
+        return;
+      }
+      marquee.scrollAmount = n;
+      print('Text speed changed to ' + n);
+    },
     exit() {
       toggle();
     }
   };
 
   commands.quit = commands.exit;
+  if (marquee) {
+    commands.read = commands.cat;
+  }
 
   function longestCommonPrefix(arr) {
     if (!arr.length) return '';

--- a/index.html
+++ b/index.html
@@ -47,8 +47,8 @@
   <div id="lava-container"></div>
   <header>
     <h1 class="wink">Caleb Fedyshen</h1>
-    <marquee behavior="scroll" direction="left" scrollamount="6">
-      Welcome to my blogthing – I heard all the best programmers have the most retro looking websites. There are many secrets on this site, many more on the desktop version of the site than mobile. Have fun! I hope you're having a great day. Now here's the entire script of the bee movie: NARRATOR: 
+    <marquee behavior="scroll" direction="left" scrollamount="100">
+      Welcome to my blogthing – I heard all the best programmers have the most retro looking websites. There are many secrets on this site, many more on the desktop version of the site than mobile. Have fun! I hope you're having a great day. Now here's the entire script of the bee movie: NARRATOR:
     </marquee>
     <nav>
       <a href="index.html">Home</a>


### PR DESCRIPTION
## Summary
- enable custom terminal commands only on `index.html`
- add `cat`/`read` command to display a text file in the marquee
- add `speed` command for controlling marquee scroll amount
- default marquee speed set to 100

## Testing
- `python3 scripts/check_links.py`

------
https://chatgpt.com/codex/tasks/task_e_6840b0b3877883328bda1f41c732b740