### PR TITLE
Fix THREE import for lava orb

### DIFF
--- a/assets/js/lavaOrb.js
+++ b/assets/js/lavaOrb.js
@@ -1,4 +1,5 @@
 // lavaOrb.js
+import * as THREE from './three.module.min.js';
 
 // — init renderer, scene, camera
 const scene    = new THREE.Scene();

--- a/index.html
+++ b/index.html
@@ -124,11 +124,7 @@
     <strong>A</strong>fter decoding, <strong>S</strong>ubmit
     <strong>C</strong>ollected <strong>I</strong>ntegers.
   </p>
-  <script type="module">
-    import * as THREE from "./assets/js/three.module.min.js";
-    window.THREE = THREE;
-    import "./assets/js/lavaOrb.js";
-  </script>
+  <script type="module" src="assets/js/lavaOrb.js"></script>
   <script src="assets/js/keypad.js"></script>
   <script src="assets/js/mobileCTA.js"></script>
   <script src="assets/js/terminal.js"></script>


### PR DESCRIPTION
## Summary
- import Three.js in lavaOrb.js
- simplify index.html module setup

## Testing
- `python3 scripts/check_links.py`

------
https://chatgpt.com/codex/tasks/task_e_684105e88f748332988fe44083348f7f