### PR TITLE
Add lava lamp toggle button

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -210,6 +210,21 @@ a:hover    { color: #FF0000; text-decoration: underline; }
   cursor: pointer;
 }
 
+.lava-button {
+  width: 88px;
+  height: 31px;
+  padding: 0;
+  font-family: "Courier New", monospace;
+  font-size: 0.8rem;
+  background: #C0C0C0;
+  border: 2px outset #FFFFFF;
+  cursor: pointer;
+}
+
+.lava-button:active {
+  border-style: inset;
+}
+
 #keypad button:active {
   border-style: inset;
 }
@@ -267,7 +282,7 @@ a:hover    { color: #FF0000; text-decoration: underline; }
   #terminalLink {
     display: none !important;
   }
-  .buttons88x31 .linux-button {
+  .buttons88x31 .lava-button {
     display: none;
   }
 }

--- a/assets/js/lavaOrb.js
+++ b/assets/js/lavaOrb.js
@@ -8,7 +8,7 @@ camera.position.z = 3;
 
 const renderer = new THREE.WebGLRenderer({ antialias: true });
 renderer.setSize(innerWidth, innerHeight);
-document.getElementById("lava-container").appendChild(renderer.domElement);
+const container = document.getElementById("lava-container");
 
 // — uniforms
 const uniforms = { time: { value: 0 } };
@@ -51,6 +51,7 @@ window.addEventListener('resize', () => {
 });
 
 // — animation loop
+let animationId = null;
 function animate() {
   uniforms.time.value += 0.01;
 
@@ -64,6 +65,23 @@ function animate() {
   glow.rotation.copy(orb.rotation);
 
   renderer.render(scene, camera);
-  requestAnimationFrame(animate);
+  animationId = requestAnimationFrame(animate);
 }
-animate();
+
+export function startLava() {
+  if (animationId) return;
+  if (!container.contains(renderer.domElement)) {
+    container.appendChild(renderer.domElement);
+  }
+  animate();
+}
+
+export function stopLava() {
+  if (animationId) {
+    cancelAnimationFrame(animationId);
+    animationId = null;
+  }
+  if (container.contains(renderer.domElement)) {
+    container.removeChild(renderer.domElement);
+  }
+}

--- a/assets/js/lavaToggle.js
+++ b/assets/js/lavaToggle.js
@@ -1,0 +1,17 @@
+import { startLava, stopLava } from './lavaOrb.js';
+
+(() => {
+  const btn = document.getElementById('lava-toggle-btn');
+  if (!btn) return;
+  let active = false;
+  btn.addEventListener('click', () => {
+    active = !active;
+    if (active) {
+      startLava();
+      btn.textContent = 'Lava Lamp: ON';
+    } else {
+      stopLava();
+      btn.textContent = 'Lava Lamp';
+    }
+  });
+})();

--- a/index.html
+++ b/index.html
@@ -96,7 +96,7 @@
 
         <div class="buttons88x31" align="center">
           <img src="https://raw.githubusercontent.com/vilgacx/88x31/main/gifs/html3.gif" alt="HTML Power">
-          <img class="linux-button" src="https://raw.githubusercontent.com/vilgacx/88x31/main/gifs/linux_powered.gif" alt="Linux Powered">
+          <button id="lava-toggle-btn" class="lava-button">Lava Lamp</button>
         <a href="https://oyster-app-qu3oz.ondigitalocean.app/" target="_blank" rel="noopener">
           <img src="https://raw.githubusercontent.com/vilgacx/88x31/main/gifs/click_here.gif" alt="Click Here">
         </a>
@@ -124,7 +124,7 @@
     <strong>A</strong>fter decoding, <strong>S</strong>ubmit
     <strong>C</strong>ollected <strong>I</strong>ntegers.
   </p>
-  <script type="module" src="assets/js/lavaOrb.js"></script>
+  <script type="module" src="assets/js/lavaToggle.js"></script>
   <script src="assets/js/keypad.js"></script>
   <script src="assets/js/mobileCTA.js"></script>
   <script src="assets/js/terminal.js"></script>


### PR DESCRIPTION
## Summary
- update *lavaOrb.js* to expose `startLava` and `stopLava`
- add new `lavaToggle.js` module to handle toggle button
- replace the Linux Powered button with a `Lava Lamp` button
- style the new button and hide it on small screens

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68410bec4f108332b415e53f74ae8f84