### PR TITLE
Improve lava lamp toggle visuals

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -219,6 +219,11 @@ a:hover    { color: #FF0000; text-decoration: underline; }
   background: #C0C0C0;
   border: 2px outset #FFFFFF;
   cursor: pointer;
+  vertical-align: middle;
+}
+
+.buttons88x31 img {
+  vertical-align: middle;
 }
 
 .lava-button:active {
@@ -274,6 +279,17 @@ a:hover    { color: #FF0000; text-decoration: underline; }
   right: 8px;
   font-family: "Courier New", Courier, monospace;
   font-size: 0.8rem;
+}
+
+/* semi-transparent boxes when lava lamp is on */
+body.lava-on header,
+body.lava-on .main-column,
+body.lava-on .reading-sidebar {
+  opacity: 0.8;
+}
+
+body.lava-on #terminal-overlay {
+  border-top: 4px solid #00FF00;
 }
 
 /* Hide terminal overlay and link on small screens */

--- a/assets/js/lavaToggle.js
+++ b/assets/js/lavaToggle.js
@@ -9,9 +9,11 @@ import { startLava, stopLava } from './lavaOrb.js';
     if (active) {
       startLava();
       btn.textContent = 'Lava Lamp: ON';
+      document.body.classList.add('lava-on');
     } else {
       stopLava();
       btn.textContent = 'Lava Lamp';
+      document.body.classList.remove('lava-on');
     }
   });
 })();


### PR DESCRIPTION
## Summary
- keep lava button aligned with other badges
- fade header, posts, and reading list when lava lamp is active
- add green line to terminal overlay when lava lamp is on
- toggle the lava-on class in JavaScript

## Testing
- `python3 scripts/check_links.py`

------
https://chatgpt.com/codex/tasks/task_e_68410f54c6c48332a1c7942f9552d653