### PR TITLE
Automate sitemap updates

### DIFF
--- a/.github/workflows/generate_sitemap.yml
+++ b/.github/workflows/generate_sitemap.yml
@@ -1,0 +1,23 @@
+name: Update Sitemap
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+      - name: Generate sitemap
+        run: python scripts/generate_sitemap.py
+      - name: Commit and push
+        uses: stefanzweifel/git-auto-commit-action@v5
+        with:
+          commit_message: 'chore: update sitemap'
+          file_pattern: sitemap.xml

--- a/README.md
+++ b/README.md
@@ -42,6 +42,8 @@ To publish:
 2. Enable GitHub Pages in your repository settings
 3. Push your changes to `main` or a `gh-pages` branch
 
+A GitHub Actions workflow automatically regenerates `sitemap.xml` after each push. You can also run `python3 scripts/generate_sitemap.py` locally if needed.
+
 ## Contact
 
 Built by Caleb Fedyshen  

--- a/robots.txt
+++ b/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://hyprpixl.github.io/sitemap.xml

--- a/scripts/generate_sitemap.py
+++ b/scripts/generate_sitemap.py
@@ -1,0 +1,30 @@
+import os
+
+BASE_URL = "https://hyprpixl.github.io"
+
+
+def gather_html_files(root="."):
+    files = []
+    for dirpath, dirs, filenames in os.walk(root):
+        for name in filenames:
+            if name.endswith(".html"):
+                rel_path = os.path.relpath(os.path.join(dirpath, name), root)
+                files.append(rel_path)
+    return sorted(files)
+
+
+def main():
+    pages = gather_html_files(".")
+    with open("sitemap.xml", "w", encoding="utf-8") as f:
+        f.write("<?xml version='1.0' encoding='UTF-8'?>\n")
+        f.write("<urlset xmlns='http://www.sitemaps.org/schemas/sitemap/0.9'>\n")
+        for page in pages:
+            url = f"{BASE_URL}/{page.replace(os.sep, '/')}"
+            f.write("  <url>\n")
+            f.write(f"    <loc>{url}</loc>\n")
+            f.write("  </url>\n")
+        f.write("</urlset>\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -1,0 +1,36 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<urlset xmlns='http://www.sitemaps.org/schemas/sitemap/0.9'>
+  <url>
+    <loc>https://hyprpixl.github.io/404.html</loc>
+  </url>
+  <url>
+    <loc>https://hyprpixl.github.io/about.html</loc>
+  </url>
+  <url>
+    <loc>https://hyprpixl.github.io/index.html</loc>
+  </url>
+  <url>
+    <loc>https://hyprpixl.github.io/pages/classified-archive.html</loc>
+  </url>
+  <url>
+    <loc>https://hyprpixl.github.io/posts/ai-mistakes-internship-apps.html</loc>
+  </url>
+  <url>
+    <loc>https://hyprpixl.github.io/posts/codex-agentic-programming.html</loc>
+  </url>
+  <url>
+    <loc>https://hyprpixl.github.io/posts/deploying-python-apps-databricks.html</loc>
+  </url>
+  <url>
+    <loc>https://hyprpixl.github.io/posts/internships-hard-to-get.html</loc>
+  </url>
+  <url>
+    <loc>https://hyprpixl.github.io/posts/killing-it-in-cs-part-2.html</loc>
+  </url>
+  <url>
+    <loc>https://hyprpixl.github.io/posts/pacesetter-launch.html</loc>
+  </url>
+  <url>
+    <loc>https://hyprpixl.github.io/posts/three-best-strategies-cs-degree.html</loc>
+  </url>
+</urlset>


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to regenerate sitemap and commit it
- update publishing instructions in README

## Testing
- `python3 scripts/generate_sitemap.py`
- `python3 scripts/check_links.py`


------
https://chatgpt.com/codex/tasks/task_e_6841a7a4fbf88332a6694e178f4c91a8