### PR TITLE
Fix LinkedIn URL

### DIFF
--- a/about.html
+++ b/about.html
@@ -21,7 +21,7 @@
         <p>
           I build custom software that <strong>saves businesses time and energy—guaranteed.</strong><br>
           <a href="mailto:hyprpixlstudios@gmail.com">HyprPixlStudios@gmail.com</a> |
-          <a href="https://www.linkedin.com/in/caleb%C2%ADfedyshen" target="_blank" rel="noopener">LinkedIn</a>
+          <a href="https://www.linkedin.com/in/caleb-fedyshen" target="_blank" rel="noopener">LinkedIn</a>
         </p>
 
         <h3>Experience</h3>


### PR DESCRIPTION
## Summary
- fix broken LinkedIn link on About page

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6841a791bd648332a6ec39bad9cd512f