### PR TITLE
Rename cat command

### DIFF
--- a/assets/js/terminal.js
+++ b/assets/js/terminal.js
@@ -28,7 +28,7 @@
     help() {
       let base = 'Commands: help, quote, clear, ls, cd <link>, pwd, date, whoami, echo <text>, fortune, exit';
       if (marquee) {
-        base += ', cat [file], speed <amount>';
+        base += ', scrolltext [file], speed <amount>';
       }
       print(base);
     },
@@ -89,7 +89,7 @@
       print('................||----w.||');
       print('................||......||');
     },
-    cat(file) {
+    scrolltext(file) {
       if (!marquee) {
         print('This command is only available on the index page.');
         return;
@@ -128,7 +128,7 @@
 
   commands.quit = commands.exit;
   if (marquee) {
-    commands.read = commands.cat;
+    commands.read = commands.scrolltext;
   }
 
   function longestCommonPrefix(arr) {


### PR DESCRIPTION
## Summary
- rename cat command to scrolltext in terminal

## Testing
- `python3 scripts/check_links.py`
- `python3 scripts/build.py`
- `python3 scripts/generate_sitemap.py`


------
https://chatgpt.com/codex/tasks/task_e_68541faba76483328b1d83db2ed607f9