### PR TITLE
Fix terminal prompt display

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -294,13 +294,22 @@ a:hover    { color: #FF0000; text-decoration: underline; }
   z-index: 9999;
 }
 
-#terminal-overlay input {
-  width: 100%;
+#terminal-current {
+  display: flex;
+}
+
+#terminal-current input {
+  flex: 1;
   background: transparent;
   border: none;
   color: inherit;
   font: inherit;
   outline: none;
+}
+
+#terminal-prompt {
+  margin-right: 4px;
+  white-space: pre;
 }
 
 #terminalLink {

--- a/assets/js/terminal.js
+++ b/assets/js/terminal.js
@@ -1,10 +1,13 @@
 (function() {
   const overlay = document.createElement('div');
   overlay.id = 'terminal-overlay';
-  overlay.innerHTML = '<div id="terminal-output"></div><input id="terminal-input" type="text" autocomplete="off" />';
+  overlay.innerHTML = '<div id="terminal-output"></div>' +
+    '<div id="terminal-current"><span id="terminal-prompt"></span>' +
+    '<input id="terminal-input" type="text" autocomplete="off" /></div>';
   document.body.appendChild(overlay);
 
   const output = overlay.querySelector('#terminal-output');
+  const promptEl = overlay.querySelector('#terminal-prompt');
   const input = overlay.querySelector('#terminal-input');
   const marquee = document.querySelector('marquee');
   const textFiles = ['bee-movie.txt'];
@@ -44,6 +47,9 @@
   }
 
   const userName = getUserName();
+  if (promptEl) {
+    promptEl.textContent = '[' + userName + ']>';
+  }
 
   const commands = {
     help() {


### PR DESCRIPTION
## Summary
- update terminal overlay HTML structure
- show the prompt before the input
- style prompt and input container

## Testing
- `python3 scripts/check_links.py`
- `python3 scripts/generate_sitemap.py` *(no changes committed)*

------
https://chatgpt.com/codex/tasks/task_e_6854456df9788332abd9b1e515e52321