### PR TITLE
Implement relative cd paths

### DIFF
--- a/assets/js/terminal.js
+++ b/assets/js/terminal.js
@@ -74,11 +74,19 @@
         print('Usage: cd <link>');
         return;
       }
+
       const match = links.find(l => l === target || l.startsWith(target));
       if (match) {
         localStorage.setItem('terminal-open', 'true');
         window.location.href = match;
-      } else {
+        return;
+      }
+
+      try {
+        const url = new URL(target, window.location.href);
+        localStorage.setItem('terminal-open', 'true');
+        window.location.href = url.href;
+      } catch (err) {
         print('No such link');
       }
     },


### PR DESCRIPTION
## Summary
- add relative path support to the terminal `cd` command

## Testing
- `python3 scripts/check_links.py`

------
https://chatgpt.com/codex/tasks/task_e_685445e4c6008332a93bd24d1863ac0a