### PR TITLE
Fix banner width and center editor box

### DIFF
--- a/pages/video-presenter.html
+++ b/pages/video-presenter.html
@@ -11,8 +11,8 @@
       font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
       margin: 0;
       padding: 0;
-      background: #f4f4f9;
-      color: #333;
+      background: #121212;
+      color: #eee;
       display: flex;
       flex-direction: column;
       align-items: center;
@@ -22,13 +22,17 @@
     h4 {
       margin: 0;
       font-size: 1.2rem;
-      color: #444;
+      color: #ddd;
+    }
+
+    header {
+      width: 100%;
     }
 
     /* Controls Container */
     #controls {
       margin: 1.5rem 0;
-      background: #fff;
+      background: #333;
       padding: 1rem 1.5rem;
       border-radius: 8px;
       box-shadow: 0 4px 12px rgba(0,0,0,0.1);
@@ -74,6 +78,7 @@
       display: flex;
       align-items: center;
       justify-content: center;
+      margin: 1rem auto;
       transition: height 0.3s ease;
       position: relative;
     }
@@ -117,7 +122,7 @@
       width: 80%;
       max-width: 1200px;
       margin: 1rem auto;
-      background: #fff;
+      background: #222;
       padding: 1rem 1.5rem;
       border-radius: 8px;
       box-shadow: 0 4px 12px rgba(0,0,0,0.1);
@@ -136,9 +141,9 @@
       justify-content: space-between;
       align-items: center;
       padding: 0.4rem 0;
-      border-bottom: 1px solid #eee;
+      border-bottom: 1px solid #444;
       font-size: 0.95rem;
-      color: #555;
+      color: #ddd;
     }
 
     #stopList li:last-child {


### PR DESCRIPTION
## Summary
- make the header span the full width on `video-presenter.html`
- switch the page to a dark theme
- center the video editor box when a video is loaded

## Testing
- `python3 scripts/check_links.py`


------
https://chatgpt.com/codex/tasks/task_e_6866fe7b12cc83329ecd4129f84c1dc3