### PR TITLE
fix: keep solved countries colored

### DIFF
--- a/pages/neon-geoguess.html
+++ b/pages/neon-geoguess.html
@@ -353,8 +353,8 @@ function highlightHover(e){
 }
 function resetHover(e){
   const layer = e.target;
-  if(currentId && layer.__id === currentId && layer.__lockedColor){
-    // keep target's color if already solved/missed
+  if(layer.__lockedColor){
+    // keep solved/missed country's color
     layer.setStyle({ weight: 1.3, color: 'rgba(255,255,255,0.9)' });
   }else{
     layer.setStyle(baseStyle());


### PR DESCRIPTION
## Summary
- keep solved or missed countries highlighted after hover to show progress

## Testing
- `python3 scripts/check_links.py`
- `python3 scripts/build.py`


------
https://chatgpt.com/codex/tasks/task_e_689cdfd8ec1c83329a1f2de5a425641f