### PR TITLE
fix cartoguesser color reset bug

### DIFF
--- a/pages/cartoguesser.html
+++ b/pages/cartoguesser.html
@@ -336,10 +336,10 @@ function highlightHover(e){
 }
 function resetHover(e){
   const layer = e.target;
-  if(currentId && layer.__id === currentId && layer.__lockedColor){
-    // keep target's color if already solved/missed
+  if(layer.__lockedColor){
+    // keep solved/missed country's color when moving cursor away
     layer.setStyle({ weight: 1.3, color: 'rgba(255,255,255,0.9)' });
-  }else{
+  } else {
     layer.setStyle(baseStyle());
   }
 }


### PR DESCRIPTION
## Summary
- keep CartoGuesser country colors from resetting when moving the mouse away after a guess

## Testing
- `python scripts/check_links.py`


------
https://chatgpt.com/codex/tasks/task_e_689ceede14d883328031cb2abd05a4fe