### PR TITLE
Reset highlights when starting a new CartoGuessr round

### DIFF
--- a/pages/cartoguesser.html
+++ b/pages/cartoguesser.html
@@ -437,6 +437,12 @@ function getRegionIds(path){
    Game flow
 ========================= */
 function setupForRegion(key){
+  // Reset any previous round coloring/highlights
+  countriesLayer.eachLayer(layer=>{
+    layer.setStyle(baseStyle());
+    delete layer.__lockedColor;
+  });
+
   const wanted = new Set(getRegionIds(key).map(i=>i.toUpperCase()));
   const ids = [];
   countriesLayer.eachLayer(layer=>{


### PR DESCRIPTION
## Summary
- Clear any previously selected countries when starting a new round
- Ensure all map layers return to the base style before choosing new targets

## Testing
- `python scripts/check_links.py`
- `python scripts/build.py`


------
https://chatgpt.com/codex/tasks/task_e_689f8b412e2c8332ad365a9ab11fd944