### PR TITLE
Add meta description and OG tags for about page

### DIFF
--- a/about.html
+++ b/about.html
@@ -5,6 +5,10 @@
     <title>About • Caleb Fedyshen</title>
     <meta name="viewport" content="width=device-width,initial-scale=1">
     <link rel="stylesheet" href="assets/css/style.css">
+    <meta name="description" content="Short summary of Caleb Fedyshen’s experience and services.">
+    <meta property="og:title" content="About • Caleb Fedyshen">
+    <meta property="og:description" content="Short summary of Caleb Fedyshen’s experience and services.">
+    <meta property="og:image" content="assets/images/terminal.png">
   </head>
   <body>
     <header>


### PR DESCRIPTION
## Summary
- add meta description to about page
- include Open Graph tags with image for rich previews

## Testing
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a0c19135c483329b50912e011db83b