### PR TITLE
Add post on replacing costly enterprise software

### DIFF
--- a/index.html
+++ b/index.html
@@ -85,6 +85,7 @@
     <main class="main-column">
       <h2>Blog Posts</h2>
       <ul>
+        <li><time datetime="2025-06-15">15 Jun 2025</time> <a href="posts/killing-expensive-enterprise-software.html">Expensive Enterprise Software Is Dying — I Saved $70K/Month by Killing It</a></li>
         <li><time datetime="2025-06-04">4 Jun 2025</time> <a href="posts/codex-agentic-programming.html">Codex Builds My Blog a Terminal</a></li>
         <li><time datetime="2025-05-05">5 May 2025</time> <a href="posts/pacesetter-launch.html">Launching the Plains Pacesetter Step Challenge</a></li>
         <li><time datetime="2025-04-30">30 Apr 2025</time> <a href="posts/deploying-python-apps-databricks.html">Deploying Python Apps on Databricks: What No One Tells You</a></li>

--- a/posts/killing-expensive-enterprise-software.html
+++ b/posts/killing-expensive-enterprise-software.html
@@ -1,0 +1,35 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Expensive Enterprise Software Is Dying — I Saved $70K/Month by Killing It</title>
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <link rel="stylesheet" href="../assets/css/style.css">
+  <meta property="og:title" content="Expensive Enterprise Software Is Dying — I Saved $70K/Month by Killing It">
+  <meta property="og:description" content="A custom Flask app replaced a legacy check image tool and slashed costs from $70K to a few hundred dollars per month.">
+  <meta property="og:image" content="../assets/images/rippedcheque.png">
+</head>
+<body>
+<header>
+  <h1>Expensive Enterprise Software Is Dying — I Saved $70K/Month by Killing It</h1>
+  <nav>
+  <a href="/index.html">Home</a>
+  <a href="/about.html">About Me</a>
+  <a href="https://www.linkedin.com/in/caleb-fedyshen" target="_blank" rel="noopener">LinkedIn ↗</a>
+</nav>
+</header>
+
+<main><article>
+<p><em>15 Jun 2025 • Calgary, AB</em></p>
+
+<p>Expensive enterprise software is dying, and I saved <strong>$70k per month</strong> by killing it. Here’s the thing: there are 9.8 million bank check images that Plains needs to retrieve accurately and with ease—that's 4.9 million checks front and back! Image Viewer (an app from a retail bank) is a <em>legacy</em> piece of software that lets companies find and view bank cheques. Unfortunately (or fortunately for me) it is being phased out and the replacement is charged on a per retrieval basis. The estimated cost of this new software, for Plains All American, is seventy thousand dollars a month! This is where I come in: I built an app that lets the treasury team do exactly this, from the data pipeline to the front end, and it costs only a few hundred dollars a month. My app entirely replaces Image Viewer, does the job quicker, and automates manual steps. I learned a ton building this and am absolutely certain there are countless opportunities like this across all businesses from big to small.</p>
+
+<p><img src="../assets/images/rippedcheque.png" alt="Ripped cheque"></p>
+
+<p>On the technical side, the app was built in Python Flask with a Html + Css + JS frontend, and the data pipeline involved multithreaded extraction of terabytes of images from thousands of zip files, parsing millions of entries from xml into a database, and setting that all to run incrementally so the information is always up to date. The app was deployed on the Databricks Apps platform, which I highly recommend checking out if your company runs Databricks at all.</p>
+
+<p>#Python #Flask #Databricks #CostSavings</p>
+</article></main>
+</body>
+<script src="../assets/js/terminal.js"></script>
+</html>

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -34,6 +34,9 @@
     <loc>https://hyprpixl.github.io/posts/internships-hard-to-get.html</loc>
   </url>
   <url>
+    <loc>https://hyprpixl.github.io/posts/killing-expensive-enterprise-software.html</loc>
+  </url>
+  <url>
     <loc>https://hyprpixl.github.io/posts/killing-it-in-cs-part-2.html</loc>
   </url>
   <url>


### PR DESCRIPTION
## Summary
- Add post detailing how a custom Flask app replaced a legacy check image viewer and saved $70K per month.
- Reference rippedcheque.png for the associated imagery and update the home page listing.
- Regenerate sitemap for the new post.

## Testing
- `python3 scripts/build.py`
- `python3 scripts/generate_sitemap.py`
- `python3 scripts/check_links.py`


------
https://chatgpt.com/codex/tasks/task_e_68a0c08c10e48332b7050a90a8a3c74b