### PR TITLE
Improve about page headline contrast and contact info

### DIFF
--- a/about.html
+++ b/about.html
@@ -27,7 +27,7 @@
     .wrap { max-width: 1100px; margin: 24px auto 96px; padding: 0 20px; }
     .hero { background: linear-gradient(180deg, rgba(255,255,255,.04), rgba(255,255,255,0)); border: 1px solid rgba(255,255,255,.06); padding: 28px; border-radius: var(--radius); display: grid; gap: 18px; }
     .eyebrow { text-transform: uppercase; letter-spacing: .12em; font-size: .78rem; color: var(--text); font-weight: 700; }
-    #about-headline { font-size: clamp(1.9rem, 4vw, 2.6rem); line-height: 1.2; margin: 0; font-weight: 800; }
+    #about-headline { font-size: clamp(1.9rem, 4vw, 2.6rem); line-height: 1.2; margin: 0; font-weight: 900; color: var(--text); }
     .sub { color: var(--muted); max-width: 75ch; }
     .cta { display: flex; flex-wrap: wrap; gap: 12px; margin-top: 4px; }
     .btn { display: inline-flex; align-items: center; gap: 10px; padding: 12px 16px; border-radius: 12px; font-weight: 700; border: 1px solid rgba(255,255,255,.12); background: #171922; }
@@ -67,8 +67,7 @@
     "@type":"Person",
     "name":"Caleb Fedyshen",
     "jobTitle":"Software Developer / Data Architect",
-    "email":"mailto:cfedyshen@gmail.com",
-    "telephone":"+1-587-830-3754",
+    "email":"mailto:hyprpixlstudios@gmail.com",
     "url":"https://cfedyshen.com/about.html",
     "sameAs":[
       "https://www.linkedin.com/in/caleb-fedyshen",
@@ -102,8 +101,7 @@
         If you’re spending big on clunky software—or spending people’s time to work around it—I can fix that.
       </p>
       <div class="cta" role="group" aria-label="Primary calls to action">
-        <a class="btn btn--primary" href="mailto:cfedyshen@gmail.com?subject=Project%20fit%20call%20with%20Caleb&body=Hi%20Caleb,%20we're%20considering%20a%20project...">Book a fit call</a>
-        <a class="btn" href="tel:+15878303754">Call 587-830-3754</a>
+        <a class="btn btn--primary" href="mailto:hyprpixlstudios@gmail.com?subject=Project%20fit%20call%20with%20Caleb&body=Hi%20Caleb,%20we're%20considering%20a%20project...">Book a fit call</a>
         <a class="btn" href="https://www.linkedin.com/in/caleb-fedyshen" target="_blank" rel="noopener">LinkedIn ↗</a>
       </div>
     </section>
@@ -214,12 +212,12 @@
       <article class="card">
         <h2 id="contact">Contact</h2>
         <p><strong>Caleb Fedyshen</strong><br>
-          <a href="mailto:cfedyshen@gmail.com">cfedyshen@gmail.com</a> · <a href="tel:+15878303754">587-830-3754</a><br>
+          <a href="mailto:hyprpixlstudios@gmail.com">hyprpixlstudios@gmail.com</a><br>
           <a href="https://www.linkedin.com/in/caleb-fedyshen" target="_blank" rel="noopener">LinkedIn</a> · <a href="/blog">Blog</a>
         </p>
         <p class="disclaimer">References available on request (former leaders at Suncor).</p>
         <div class="cta">
-          <a class="btn btn--primary" href="mailto:cfedyshen@gmail.com?subject=Project%20fit%20call%20with%20Caleb&body=Hi%20Caleb,%20we're%20considering%20a%20project...">Let’s talk</a>
+          <a class="btn btn--primary" href="mailto:hyprpixlstudios@gmail.com?subject=Project%20fit%20call%20with%20Caleb&body=Hi%20Caleb,%20we're%20considering%20a%20project...">Let’s talk</a>
           <a class="btn" href="/Caleb-Fedyshen-Resume.pdf">View resume (PDF)</a>
         </div>
       </article>


### PR DESCRIPTION
## Summary
- darken and bold the about page headline for better readability
- remove phone number and switch contact links to hyprpixlstudios@gmail.com
- update structured data to only include the new email

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open '/workspace/hyprpixl.github.io/package.json')*

------
https://chatgpt.com/codex/tasks/task_e_68a0cf9839308332ad01539405dbbc0c