### PR TITLE
Exclude non-public directories from sitemap

### DIFF
--- a/scripts/generate_sitemap.py
+++ b/scripts/generate_sitemap.py
@@ -5,7 +5,9 @@ BASE_URL = "https://hyprpixl.github.io"
 
 def gather_html_files(root="."):
     files = []
+    exclude = {"partials", "scripts", "assets"}
     for dirpath, dirs, filenames in os.walk(root):
+        dirs[:] = [d for d in dirs if d not in exclude]
         for name in filenames:
             if name.endswith(".html"):
                 rel_path = os.path.relpath(os.path.join(dirpath, name), root)

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -25,9 +25,6 @@
     <loc>https://hyprpixl.github.io/pages/video-presenter.html</loc>
   </url>
   <url>
-    <loc>https://hyprpixl.github.io/partials/nav.html</loc>
-  </url>
-  <url>
     <loc>https://hyprpixl.github.io/posts/ai-mistakes-internship-apps.html</loc>
   </url>
   <url>


### PR DESCRIPTION
## Summary
- filter out `partials`, `scripts`, and `assets` folders when collecting HTML files for the sitemap
- regenerate `sitemap.xml` to include only public pages

## Testing
- `python -m py_compile scripts/generate_sitemap.py`
- `python scripts/generate_sitemap.py`


------
https://chatgpt.com/codex/tasks/task_e_68a205d6d4e48332a627cffc3b86d4bd