### PR TITLE
Reduce mind map squeeze when adding nodes

### DIFF
--- a/pages/mind-map.html
+++ b/pages/mind-map.html
@@ -590,9 +590,7 @@
         console.log(`Node color changed to: ${node.color}`);
       }
       let inertialTimer;
-      let resumeTimer;
       const inertialDelay = 300; // Duration of inertial damper in ms
-      const resumeDuration = 300; // Time for simulation to ramp up after damper
 
       document.addEventListener("keydown", (event) => {
         console.log(`Key pressed: ${event.key}`);
@@ -703,7 +701,6 @@
 
         // Clear any existing timers
         clearTimeout(inertialTimer);
-        clearTimeout(resumeTimer);
 
         // Resume the simulation after the damper duration
         inertialTimer = setTimeout(() => {
@@ -711,11 +708,8 @@
             n.fx = null;
             n.fy = null;
           });
-          // Gradually ramp the simulation back up for a smooth resume
-          simulation.alpha(0).alphaTarget(0.3).restart();
-          resumeTimer = setTimeout(() => {
-            simulation.alphaTarget(0);
-          }, resumeDuration);
+          // Restart the simulation with a lower alpha to avoid squeezing
+          simulation.alphaTarget(0).alpha(0.05).restart();
         }, inertialDelay);
       }
 
@@ -879,8 +873,8 @@
         });
       function attractAllToCenter(alpha) {
         nodes.forEach((node) => {
-          const kx = 0.1 * alpha;
-          const ky = 0.1 * alpha;
+          const kx = 0.05 * alpha;
+          const ky = 0.05 * alpha;
 
           node.vx += (width / 2 - node.x) * kx;
           node.vy += (height / 2 - node.y) * ky;


### PR DESCRIPTION
## Summary
- Restart simulation with low alpha instead of high alpha target to prevent nodes from collapsing toward center
- Weaken center attraction force for smoother layout stability

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a25a0990d48332afd13989ea826813