### PR TITLE
Add hidden WIP section with Lifehacks draft

### DIFF
--- a/index.html
+++ b/index.html
@@ -130,6 +130,7 @@
     <strong>A</strong>fter decoding, <strong>S</strong>ubmit
     <strong>C</strong>ollected <strong>I</strong>ntegers.
   </p>
+  <a href="/wip/index.html" style="display:none" aria-hidden="true" tabindex="-1">WIP</a>
   <script type="module" src="assets/js/lavaToggle.js"></script>
   <script src="assets/js/keypad.js"></script>
   <script src="assets/js/mobileCTA.js"></script>

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -51,4 +51,10 @@
   <url>
     <loc>https://hyprpixl.github.io/posts/three-best-strategies-cs-degree.html</loc>
   </url>
+  <url>
+    <loc>https://hyprpixl.github.io/wip/index.html</loc>
+  </url>
+  <url>
+    <loc>https://hyprpixl.github.io/wip/lifehacks.html</loc>
+  </url>
 </urlset>

--- a/wip/index.html
+++ b/wip/index.html
@@ -1,0 +1,26 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Work in Progress</title>
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <link rel="stylesheet" href="../assets/css/style.css">
+</head>
+<body>
+  <header>
+    <h1>Work in Progress</h1>
+    <nav>
+  <a href="/index.html">Home</a>
+  <a href="/about.html">About Me</a>
+  <a href="https://www.linkedin.com/in/caleb-fedyshen" target="_blank" rel="noopener">LinkedIn ↗</a>
+</nav>
+  </header>
+  <main>
+    <h2>Draft Posts</h2>
+    <ul>
+      <li><time datetime="2025-08-21">21 Aug 2025</time> <a href="lifehacks.html">Lifehacks</a></li>
+    </ul>
+  </main>
+</body>
+<script src="../assets/js/terminal.js"></script>
+</html>

--- a/wip/lifehacks.html
+++ b/wip/lifehacks.html
@@ -1,0 +1,75 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Lifehacks (WIP)</title>
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <link rel="stylesheet" href="../assets/css/style.css">
+  <meta property="og:title" content="Lifehacks">
+  <meta property="og:description" content="High leverage habits and items I'm experimenting with.">
+  <meta property="og:image" content="../assets/images/starfield.gif">
+</head>
+<body>
+  <header>
+    <h1>Lifehacks (WIP)</h1>
+    <nav>
+  <a href="/index.html">Home</a>
+  <a href="/about.html">About Me</a>
+  <a href="https://www.linkedin.com/in/caleb-fedyshen" target="_blank" rel="noopener">LinkedIn ↗</a>
+</nav>
+  </header>
+  <main>
+    <article>
+      <p><em>21 Aug 2025 • Calgary, AB</em></p>
+      <p>Here is a list of the things I have found in life to be high leverage, as in low input relative to output.</p>
+
+      <h2>Sleep</h2>
+      <ul>
+        <li>Wear earplugs (Amazon Howard Leight 200 pack is highest dB reduction lowest cost)</li>
+        <li>Cold room</li>
+        <li>Black out blinds</li>
+        <li>Very low dose melatonin (1.25mg)</li>
+        <li>Black electrical tape will block out any small light emitting sources, always have some around.</li>
+        <li>Audiobook to get sleepy</li>
+        <li>Have eye mask bedside and for travel.</li>
+        <li>Sometime after getting into bed, tense every muscle individually from toes to face, as hard as you can for 3–5 seconds, breathe in on tense, out on relax.</li>
+      </ul>
+
+      <h2>Anxiety, Sad, or Feeling Bad</h2>
+      <p>If I do the following things in order, 90 percent of the time, at some point in the list I will be feeling better and can go about my business doing whatever I was struggling to do before. If any of the things on the list have already been done that day, skip to the next item.</p>
+      <ul>
+        <li>Drink water</li>
+        <li>L-theanine, high dose 750mg–1g</li>
+        <li>Creatine (10–15g)</li>
+        <li>Magnesium</li>
+        <li>Fish oil</li>
+        <li>Shower (maybe even a cold shower if it's a real challenging day)</li>
+        <li>Eat</li>
+        <li>Cardio</li>
+        <li>Lift weights</li>
+        <li>Ashwagandha</li>
+        <li>Sleep</li>
+      </ul>
+
+      <h2>High ROI Things to Own</h2>
+      <ul>
+        <li>An extra charger</li>
+        <li>Spare headphones (JLab Minis are great backup headphones and very portable)</li>
+        <li>Good shoe insoles</li>
+        <li>Kuru Toga mechanical pencil</li>
+        <li>Airtags</li>
+        <li>Kindle</li>
+      </ul>
+
+      <h2>Things to Keep in Your Backpack</h2>
+      <ul>
+        <li>Toothbrush/toothpaste</li>
+        <li>L-theanine</li>
+        <li>Notebook &amp; pencil</li>
+        <li>Advil</li>
+      </ul>
+    </article>
+  </main>
+</body>
+<script src="../assets/js/terminal.js"></script>
+</html>


### PR DESCRIPTION
## Summary
- Add hidden Work in Progress area accessible via terminal only.
- Create Lifehacks draft post listing high-leverage habits and gear.
- Update sitemap for new WIP pages.

## Testing
- `python3 scripts/build.py`
- `python3 scripts/generate_sitemap.py`
- `python3 scripts/check_links.py`


------
https://chatgpt.com/codex/tasks/task_e_68a77da1069c8332be097e09269b0ab4