### PR TITLE
Style guestbook comments

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -371,3 +371,13 @@ body.lava-on #terminal-overlay {
     display: none;
   }
 }
+
+/* Guestbook comment box styling */
+#giscus {
+  width: 100%;
+  max-width: 600px;
+  margin: 0 auto;
+  padding: 0.5rem;
+  background: #FFFFFF;
+  border: 6px ridge #C0C0C0;
+}

--- a/pages/guestbook.html
+++ b/pages/guestbook.html
@@ -32,7 +32,7 @@
         data-reactions-enabled="0"
         data-emit-metadata="0"
         data-input-position="bottom"
-        data-theme="light_high_contrast"
+        data-theme="noborder_light"
         data-lang="en"
         crossorigin="anonymous"
         async>


### PR DESCRIPTION
## Summary
- restyle giscus guestbook widget to fit the site layout
- switch comments to a noborder theme for better cohesion

## Testing
- `python scripts/check_links.py`


------
https://chatgpt.com/codex/tasks/task_e_68a7924d5bf48332b92052d42b6ecf2d