### PR TITLE
Remove guestbook link and tidy page navs

### DIFF
--- a/404.html
+++ b/404.html
@@ -12,7 +12,6 @@
 <nav>
   <a href="/index.html">Home</a>
   <a href="/about.html">About Me</a>
-  <a href="/pages/guestbook.html">Guestbook</a>
   <a href="https://www.linkedin.com/in/caleb-fedyshen" target="_blank" rel="noopener">LinkedIn ↗</a>
 </nav>
   </header>

--- a/about.html
+++ b/about.html
@@ -86,8 +86,6 @@
     </marquee>
     <nav>
   <a href="/index.html">Home</a>
-  <a href="/about.html">About Me</a>
-  <a href="/pages/guestbook.html">Guestbook</a>
   <a href="https://www.linkedin.com/in/caleb-fedyshen" target="_blank" rel="noopener">LinkedIn ↗</a>
 </nav>
   </header>

--- a/blog/index.html
+++ b/blog/index.html
@@ -12,7 +12,6 @@
     <nav>
   <a href="/index.html">Home</a>
   <a href="/about.html">About Me</a>
-  <a href="/pages/guestbook.html">Guestbook</a>
   <a href="https://www.linkedin.com/in/caleb-fedyshen" target="_blank" rel="noopener">LinkedIn ↗</a>
 </nav>
   </header>

--- a/index.html
+++ b/index.html
@@ -51,9 +51,7 @@
       Welcome to my blogthing – I heard all the best programmers have the most retro looking websites. There are many secrets on this site, many more on the desktop version of the site than mobile. Have fun! I hope you're having a great day.
     </marquee>
 <nav>
-  <a href="/index.html">Home</a>
   <a href="/about.html">About Me</a>
-  <a href="/pages/guestbook.html">Guestbook</a>
   <a href="https://www.linkedin.com/in/caleb-fedyshen" target="_blank" rel="noopener">LinkedIn ↗</a>
 </nav>
   </header>

--- a/pages/guestbook.html
+++ b/pages/guestbook.html
@@ -12,7 +12,6 @@
     <nav>
   <a href="/index.html">Home</a>
   <a href="/about.html">About Me</a>
-  <a href="/pages/guestbook.html">Guestbook</a>
   <a href="https://www.linkedin.com/in/caleb-fedyshen" target="_blank" rel="noopener">LinkedIn ↗</a>
 </nav>
   </header>

--- a/pages/unyellow.html
+++ b/pages/unyellow.html
@@ -34,7 +34,6 @@
   <nav>
   <a href="/index.html">Home</a>
   <a href="/about.html">About Me</a>
-  <a href="/pages/guestbook.html">Guestbook</a>
   <a href="https://www.linkedin.com/in/caleb-fedyshen" target="_blank" rel="noopener">LinkedIn ↗</a>
 </nav>
 </header>

--- a/pages/video-presenter.html
+++ b/pages/video-presenter.html
@@ -202,7 +202,6 @@
   <nav>
   <a href="/index.html">Home</a>
   <a href="/about.html">About Me</a>
-  <a href="/pages/guestbook.html">Guestbook</a>
   <a href="https://www.linkedin.com/in/caleb-fedyshen" target="_blank" rel="noopener">LinkedIn ↗</a>
 </nav>
 </header>

--- a/partials/nav.html
+++ b/partials/nav.html
@@ -1,6 +1,5 @@
 <nav>
   <a href="/index.html">Home</a>
   <a href="/about.html">About Me</a>
-  <a href="/pages/guestbook.html">Guestbook</a>
   <a href="https://www.linkedin.com/in/caleb-fedyshen" target="_blank" rel="noopener">LinkedIn ↗</a>
 </nav>

--- a/posts/ai-mistakes-internship-apps.html
+++ b/posts/ai-mistakes-internship-apps.html
@@ -15,7 +15,6 @@
   <nav>
   <a href="/index.html">Home</a>
   <a href="/about.html">About Me</a>
-  <a href="/pages/guestbook.html">Guestbook</a>
   <a href="https://www.linkedin.com/in/caleb-fedyshen" target="_blank" rel="noopener">LinkedIn ↗</a>
 </nav>
 </header>

--- a/posts/codex-agentic-programming.html
+++ b/posts/codex-agentic-programming.html
@@ -15,7 +15,6 @@
   <nav>
   <a href="/index.html">Home</a>
   <a href="/about.html">About Me</a>
-  <a href="/pages/guestbook.html">Guestbook</a>
   <a href="https://www.linkedin.com/in/caleb-fedyshen" target="_blank" rel="noopener">LinkedIn ↗</a>
 </nav>
 </header>

--- a/posts/deploying-python-apps-databricks.html
+++ b/posts/deploying-python-apps-databricks.html
@@ -15,7 +15,6 @@
       <nav>
   <a href="/index.html">Home</a>
   <a href="/about.html">About Me</a>
-  <a href="/pages/guestbook.html">Guestbook</a>
   <a href="https://www.linkedin.com/in/caleb-fedyshen" target="_blank" rel="noopener">LinkedIn ↗</a>
 </nav>
     </header>

--- a/posts/internships-hard-to-get.html
+++ b/posts/internships-hard-to-get.html
@@ -15,7 +15,6 @@
   <nav>
   <a href="/index.html">Home</a>
   <a href="/about.html">About Me</a>
-  <a href="/pages/guestbook.html">Guestbook</a>
   <a href="https://www.linkedin.com/in/caleb-fedyshen" target="_blank" rel="noopener">LinkedIn ↗</a>
 </nav>
 </header>

--- a/posts/killing-expensive-enterprise-software.html
+++ b/posts/killing-expensive-enterprise-software.html
@@ -15,7 +15,6 @@
   <nav>
   <a href="/index.html">Home</a>
   <a href="/about.html">About Me</a>
-  <a href="/pages/guestbook.html">Guestbook</a>
   <a href="https://www.linkedin.com/in/caleb-fedyshen" target="_blank" rel="noopener">LinkedIn ↗</a>
 </nav>
 </header>

--- a/posts/killing-it-in-cs-part-2.html
+++ b/posts/killing-it-in-cs-part-2.html
@@ -15,7 +15,6 @@
   <nav>
   <a href="/index.html">Home</a>
   <a href="/about.html">About Me</a>
-  <a href="/pages/guestbook.html">Guestbook</a>
   <a href="https://www.linkedin.com/in/caleb-fedyshen" target="_blank" rel="noopener">LinkedIn ↗</a>
 </nav>
 </header>

--- a/posts/pacesetter-launch.html
+++ b/posts/pacesetter-launch.html
@@ -15,7 +15,6 @@
     <nav>
   <a href="/index.html">Home</a>
   <a href="/about.html">About Me</a>
-  <a href="/pages/guestbook.html">Guestbook</a>
   <a href="https://www.linkedin.com/in/caleb-fedyshen" target="_blank" rel="noopener">LinkedIn ↗</a>
 </nav>
   </header>

--- a/posts/three-best-strategies-cs-degree.html
+++ b/posts/three-best-strategies-cs-degree.html
@@ -15,7 +15,6 @@
   <nav>
   <a href="/index.html">Home</a>
   <a href="/about.html">About Me</a>
-  <a href="/pages/guestbook.html">Guestbook</a>
   <a href="https://www.linkedin.com/in/caleb-fedyshen" target="_blank" rel="noopener">LinkedIn ↗</a>
 </nav>
 </header>

--- a/wip/index.html
+++ b/wip/index.html
@@ -12,7 +12,6 @@
     <nav>
   <a href="/index.html">Home</a>
   <a href="/about.html">About Me</a>
-  <a href="/pages/guestbook.html">Guestbook</a>
   <a href="https://www.linkedin.com/in/caleb-fedyshen" target="_blank" rel="noopener">LinkedIn ↗</a>
 </nav>
   </header>

--- a/wip/lifehacks.html
+++ b/wip/lifehacks.html
@@ -15,7 +15,6 @@
     <nav>
   <a href="/index.html">Home</a>
   <a href="/about.html">About Me</a>
-  <a href="/pages/guestbook.html">Guestbook</a>
   <a href="https://www.linkedin.com/in/caleb-fedyshen" target="_blank" rel="noopener">LinkedIn ↗</a>
 </nav>
   </header>


### PR DESCRIPTION
## Summary
- Remove Guestbook button from navigation on all pages
- Drop Home link from homepage
- Drop About link from About page

## Testing
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a793a5d1448332b7729bcce4efa184