### PR TITLE
Wrap guestbook comments in main container

### DIFF
--- a/pages/guestbook.html
+++ b/pages/guestbook.html
@@ -15,22 +15,24 @@
   <a href="https://www.linkedin.com/in/caleb-fedyshen" target="_blank" rel="noopener">LinkedIn ↗</a>
 </nav>
   </header>
-<script src="https://giscus.app/client.js"
-        data-repo="hyprpixl/hyprpixl.github.io"
-        data-repo-id="R_kgDOOiduWw"
-        data-category="General"
-        data-category-id="DIC_kwDOOiduW84Cucvc"
-        data-mapping="specific"
-        data-term="guestbook"
-        data-strict="0"
-        data-reactions-enabled="0"
-        data-emit-metadata="0"
-        data-input-position="bottom"
-        data-theme="https://hyprpixl.github.io/assets/css/giscus-theme.css"
-        data-lang="en"
-        crossorigin="anonymous"
-        async>
-</script>
+  <main>
+    <script src="https://giscus.app/client.js"
+            data-repo="hyprpixl/hyprpixl.github.io"
+            data-repo-id="R_kgDOOiduWw"
+            data-category="General"
+            data-category-id="DIC_kwDOOiduW84Cucvc"
+            data-mapping="specific"
+            data-term="guestbook"
+            data-strict="0"
+            data-reactions-enabled="0"
+            data-emit-metadata="0"
+            data-input-position="bottom"
+            data-theme="https://hyprpixl.github.io/assets/css/giscus-theme.css"
+            data-lang="en"
+            crossorigin="anonymous"
+            async>
+    </script>
+  </main>
 </body>
 </html>
 


### PR DESCRIPTION
## Summary
- restrict guestbook comments to a centered main container for narrower width

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a7975cbc2c8332bf6fb9366e649408