### PR TITLE
Add automated "Keep Reading" related posts section to blog posts

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,6 +17,8 @@ jobs:
           python-version: '3.x'
       - name: Run build
         run: python scripts/build.py
+      - name: Inject related posts
+        run: python scripts/inject_related_posts.py
       - name: Check links
         run: python scripts/check_links.py
       - name: Commit changes

--- a/assets/css/modern-style.css
+++ b/assets/css/modern-style.css
@@ -549,11 +549,67 @@ body.modern-style .content-wrapper {
   body.modern-style header h1 {
     font-size: 1.75rem;
   }
-  
+
   body.modern-style nav a,
   body.modern-style #style-toggle-btn {
     font-size: 0.9rem;
     padding: 0.5rem 1rem;
     border-radius: 10px;
   }
+}
+
+/* Keep Reading section - modern overrides */
+body.modern-style .keep-reading {
+  background: rgba(111, 127, 87, 0.1);
+  backdrop-filter: blur(24px) saturate(200%);
+  -webkit-backdrop-filter: blur(24px) saturate(200%);
+  border: 1px solid rgba(111, 127, 87, 0.25);
+  border-radius: 16px;
+  color: var(--modern-text);
+  box-shadow: 0 4px 16px rgba(31, 38, 135, 0.08),
+              inset 0 1px 0 rgba(255, 255, 255, 0.4);
+}
+
+body.modern-style .keep-reading h2 {
+  color: var(--modern-accent-strong);
+  font-size: 1rem;
+  font-weight: 700;
+  letter-spacing: normal;
+  text-transform: none;
+  border-bottom: 2px solid rgba(111, 127, 87, 0.2);
+  padding-bottom: 0.5rem;
+  text-shadow: 0 1px 2px rgba(255, 255, 255, 0.5);
+}
+
+body.modern-style .keep-reading ul {
+  list-style: none;
+  padding-left: 0;
+}
+
+body.modern-style .keep-reading li {
+  padding: 0.6rem 0;
+  border-bottom: 1px solid rgba(111, 127, 87, 0.12);
+  transition: all 0.2s ease;
+}
+
+body.modern-style .keep-reading li:last-child {
+  border-bottom: none;
+}
+
+body.modern-style .keep-reading li:hover {
+  background: rgba(255, 255, 255, 0.2);
+  border-radius: 8px;
+  border-bottom-color: transparent;
+  transform: translateX(4px);
+}
+
+body.modern-style .keep-reading a,
+body.modern-style .keep-reading a:visited {
+  color: var(--modern-accent-strong);
+  font-weight: 500;
+}
+
+body.modern-style .keep-reading a:hover {
+  color: var(--modern-accent);
+  text-decoration: underline;
 }

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -359,6 +359,56 @@ a:hover    { color: #FF0000; text-decoration: underline; }
   text-decoration: underline;
 }
 
+/* ────────────────────────────────────────────────── */
+/* keep reading section at the bottom of posts       */
+/* ────────────────────────────────────────────────── */
+.keep-reading {
+  margin-top: 2rem;
+  padding: 0.75rem 1rem;
+  background: #000080;
+  color: #FFFF00;
+  border: 4px ridge #C0C0C0;
+  font-family: "Courier New", monospace;
+}
+
+.keep-reading h2 {
+  margin: 0 0 0.5rem 0;
+  font-size: 1rem;
+  color: #FFFF00;
+  text-transform: uppercase;
+  letter-spacing: 1px;
+}
+
+.keep-reading ul {
+  list-style-position: outside;
+  padding-left: 20px;
+  margin: 0;
+}
+
+.keep-reading li {
+  margin-bottom: 0.4rem;
+}
+
+.keep-reading time {
+  font-size: 0.85em;
+  opacity: 0.8;
+  margin-right: 0.4em;
+}
+
+.keep-reading a {
+  color: #FFFF00;
+  text-decoration: none;
+}
+
+.keep-reading a:visited {
+  color: #FFCC88;
+}
+
+.keep-reading a:hover {
+  color: #FFCC00;
+  text-decoration: underline;
+}
+
 /* keypad styles for the secret archive */
 #keypad {
   display: flex;

--- a/posts/ai-mistakes-internship-apps.html
+++ b/posts/ai-mistakes-internship-apps.html
@@ -39,6 +39,14 @@
 <p>P.S. I didn’t use AI on this post</p>
 
 <p>#cs  #chatGPT  #AI</p>
+<section class="keep-reading">
+<h2>&#9658; Keep Reading</h2>
+<ul>
+    <li><time>30 Nov 2024</time> <a href="killing-it-in-cs-part-2.html">Killing It in Computer Science (Part 2)</a></li>
+    <li><time>20 Nov 2024</time> <a href="internships-hard-to-get.html">Internships Are Hard to Get, These Tips Might Help</a></li>
+    <li><time>30 Mar 2026</time> <a href="chronolisten.html">I Built the Audiobook App That Didn't Exist</a></li>
+</ul>
+</section>
 </article></main>
 </body>
 <script src="../assets/js/styleToggle.js"></script>

--- a/posts/chronolisten.html
+++ b/posts/chronolisten.html
@@ -73,6 +73,14 @@
 
 <p><strong>TL;DR:</strong> I was frustrated that no app let me listen to my own audiobook files on my Apple Watch without a subscription or a third party server, so I spent six months building one. It's called ChronoListen, it's a one time purchase, and it's currently #1 on the App Store charts* .</p>
 
+<section class="keep-reading">
+<h2>&#9658; Keep Reading</h2>
+<ul>
+    <li><time>21 Aug 2025</time> <a href="lifehacks.html">Lifehacks</a></li>
+    <li><time>20 Jun 2025</time> <a href="software-isnt-dead-your-time-is-now.html">Software Isn't Dead. Your Time Is Now</a></li>
+    <li><time>15 Jun 2025</time> <a href="killing-expensive-enterprise-software.html">Expensive Enterprise Software Is Dying. I Saved $70K/Month by Killing It.</a></li>
+</ul>
+</section>
 </article></main>
 </body>
 <script src="../assets/js/styleToggle.js"></script>

--- a/posts/deploying-python-apps-databricks.html
+++ b/posts/deploying-python-apps-databricks.html
@@ -60,7 +60,15 @@
           Good luck—and huge kudos to the Databricks team for such an intuitive
           feature set!
         </p>
-      </article>
+      <section class="keep-reading">
+<h2>&#9658; Keep Reading</h2>
+<ul>
+    <li><time>5 May 2025</time> <a href="pacesetter-launch.html">Launching the Plains Pacesetter Step Challenge</a></li>
+    <li><time>30 Nov 2024</time> <a href="killing-it-in-cs-part-2.html">Killing It in Computer Science (Part 2)</a></li>
+    <li><time>30 Mar 2026</time> <a href="chronolisten.html">I Built the Audiobook App That Didn't Exist</a></li>
+</ul>
+</section>
+</article>
     </main>
   <script src="../assets/js/styleToggle.js"></script>
 <script src="../assets/js/terminal.js"></script>

--- a/posts/internships-hard-to-get.html
+++ b/posts/internships-hard-to-get.html
@@ -35,6 +35,14 @@
 <p>I’ll be posting plenty more of these with all the things I’ve learned over the last four years, so be sure to follow for more. My next one will detail the <em>WORST</em> ways to use AI in the application process.</p>
 
 <p>#internship  #ComputerScience  #advice</p>
+<section class="keep-reading">
+<h2>&#9658; Keep Reading</h2>
+<ul>
+    <li><time>25 Nov 2024</time> <a href="ai-mistakes-internship-apps.html">The Worst Ways to Use AI in Internship / Job Apps</a></li>
+    <li><time>15 Nov 2024</time> <a href="three-best-strategies-cs-degree.html">Three Strategies for Killing a CS Degree</a></li>
+    <li><time>30 Mar 2026</time> <a href="chronolisten.html">I Built the Audiobook App That Didn't Exist</a></li>
+</ul>
+</section>
 </article></main>
 </body>
 <script src="../assets/js/styleToggle.js"></script>

--- a/posts/killing-expensive-enterprise-software.html
+++ b/posts/killing-expensive-enterprise-software.html
@@ -31,6 +31,14 @@
 <p>On the technical side, the app was built in Python Flask with a Html + Css + JS frontend, and the data pipeline involved multithreaded extraction of terabytes of images from thousands of zip files, parsing millions of entries from xml into a database, and setting that all to run incrementally so the information is always up to date. The app was deployed on the Databricks Apps platform, which I highly recommend checking out if your company runs Databricks at all.</p>
 
 <p>#Python #Flask #Databricks #CostSavings</p>
+<section class="keep-reading">
+<h2>&#9658; Keep Reading</h2>
+<ul>
+    <li><time>20 Jun 2025</time> <a href="software-isnt-dead-your-time-is-now.html">Software Isn't Dead. Your Time Is Now</a></li>
+    <li><time>5 May 2025</time> <a href="pacesetter-launch.html">Launching the Plains Pacesetter Step Challenge</a></li>
+    <li><time>30 Mar 2026</time> <a href="chronolisten.html">I Built the Audiobook App That Didn't Exist</a></li>
+</ul>
+</section>
 </article></main>
 </body>
 <script src="../assets/js/styleToggle.js"></script>

--- a/posts/killing-it-in-cs-part-2.html
+++ b/posts/killing-it-in-cs-part-2.html
@@ -37,6 +37,14 @@
 <p>If you’re a senior student or someone who has completed a degree, pay it forward and drop some wisdom in the comments. I know I would have appreciated it a few years ago.</p>
 
 <p>#CS  #Uni  #Advice</p>
+<section class="keep-reading">
+<h2>&#9658; Keep Reading</h2>
+<ul>
+    <li><time>30 Apr 2025</time> <a href="deploying-python-apps-databricks.html">Deploying Python Apps on Databricks: What No One Tells You</a></li>
+    <li><time>25 Nov 2024</time> <a href="ai-mistakes-internship-apps.html">The Worst Ways to Use AI in Internship / Job Apps</a></li>
+    <li><time>30 Mar 2026</time> <a href="chronolisten.html">I Built the Audiobook App That Didn't Exist</a></li>
+</ul>
+</section>
 </article></main>
 </body>
 <script src="../assets/js/styleToggle.js"></script>

--- a/posts/lifehacks.html
+++ b/posts/lifehacks.html
@@ -70,7 +70,15 @@
         <li>Notebook &amp; pencil</li>
         <li>Advil</li>
       </ul>
-    </article>
+    <section class="keep-reading">
+<h2>&#9658; Keep Reading</h2>
+<ul>
+    <li><time>30 Mar 2026</time> <a href="chronolisten.html">I Built the Audiobook App That Didn't Exist</a></li>
+    <li><time>20 Jun 2025</time> <a href="software-isnt-dead-your-time-is-now.html">Software Isn't Dead. Your Time Is Now</a></li>
+    <li><time>15 Jun 2025</time> <a href="killing-expensive-enterprise-software.html">Expensive Enterprise Software Is Dying. I Saved $70K/Month by Killing It.</a></li>
+</ul>
+</section>
+</article>
   </main>
 </body>
 <script src="../assets/js/styleToggle.js"></script>

--- a/posts/pacesetter-launch.html
+++ b/posts/pacesetter-launch.html
@@ -63,7 +63,15 @@
       <p>You might be wondering if using Power Apps was worth the headache instead of rolling your own solution in Flask or raw HTML/CSS/JS. The integration with Entra ID and the Teams embedding made it absolutely worthwhile, especially at scale.</p>
       <p><strong>TL;DR:</strong> Built the data backbone for Plains’ company wide step challenge using Power Apps, MS Fabric SQL, Power Automate, and Power BI, resulting in a scalable and user friendly solution.</p>
       <p>#data #powerapps #powerbi #automation #msfabric</p>
-    </article>
+    <section class="keep-reading">
+<h2>&#9658; Keep Reading</h2>
+<ul>
+    <li><time>15 Jun 2025</time> <a href="killing-expensive-enterprise-software.html">Expensive Enterprise Software Is Dying. I Saved $70K/Month by Killing It.</a></li>
+    <li><time>30 Apr 2025</time> <a href="deploying-python-apps-databricks.html">Deploying Python Apps on Databricks: What No One Tells You</a></li>
+    <li><time>30 Mar 2026</time> <a href="chronolisten.html">I Built the Audiobook App That Didn't Exist</a></li>
+</ul>
+</section>
+</article>
   </main>
 </body>
 <script src="../assets/js/styleToggle.js"></script>

--- a/posts/software-isnt-dead-your-time-is-now.html
+++ b/posts/software-isnt-dead-your-time-is-now.html
@@ -35,6 +35,14 @@
 <p>Okay but how do we even find these opportunities? You won’t be shocked, the answer is talking to people, telling them what you’re working on. Starting with small inventive projects that get people talking, who will then reach out to you for their next idea. This touches on people’s biggest misconception about “networking” but don’t even get me started on that.</p>
 
 <p>It all essentially boils down to providing additional value, disproportionately to the cost of interacting with you via hiring you, having a conversation or even someone reading your post. (Thanks by the way, I hope you’re getting something out of this.) The opportunities to arbitrage the value of software have never been more numerous. Go have one conversation every day this week you wouldn’t have had otherwise. Everyone loves talking about problems, and you are uniquely suited to solve them.</p>
+<section class="keep-reading">
+<h2>&#9658; Keep Reading</h2>
+<ul>
+    <li><time>21 Aug 2025</time> <a href="lifehacks.html">Lifehacks</a></li>
+    <li><time>15 Jun 2025</time> <a href="killing-expensive-enterprise-software.html">Expensive Enterprise Software Is Dying. I Saved $70K/Month by Killing It.</a></li>
+    <li><time>30 Mar 2026</time> <a href="chronolisten.html">I Built the Audiobook App That Didn't Exist</a></li>
+</ul>
+</section>
 </article></main>
 </body>
 <script src="../assets/js/styleToggle.js"></script>

--- a/posts/three-best-strategies-cs-degree.html
+++ b/posts/three-best-strategies-cs-degree.html
@@ -40,6 +40,14 @@
 <p><strong>Bonus:</strong> know when good enough is good enough – sometimes that extra two percent on the grade isn’t worth twice the work. Part of the reason I felt so burned out after first year was that I hadn’t realized this yet.</p>
 
 <p>If you have more good ones, send them my way :)</p>
+<section class="keep-reading">
+<h2>&#9658; Keep Reading</h2>
+<ul>
+    <li><time>20 Nov 2024</time> <a href="internships-hard-to-get.html">Internships Are Hard to Get, These Tips Might Help</a></li>
+    <li><time>30 Mar 2026</time> <a href="chronolisten.html">I Built the Audiobook App That Didn't Exist</a></li>
+    <li><time>21 Aug 2025</time> <a href="lifehacks.html">Lifehacks</a></li>
+</ul>
+</section>
 </article></main>
 </body>
 <script src="../assets/js/styleToggle.js"></script>

--- a/scripts/inject_related_posts.py
+++ b/scripts/inject_related_posts.py
@@ -1,0 +1,82 @@
+import os
+import re
+
+POSTS = [
+    {"date": "30 Mar 2026", "href": "chronolisten.html", "title": "I Built the Audiobook App That Didn't Exist"},
+    {"date": "21 Aug 2025", "href": "lifehacks.html", "title": "Lifehacks"},
+    {"date": "20 Jun 2025", "href": "software-isnt-dead-your-time-is-now.html", "title": "Software Isn't Dead. Your Time Is Now"},
+    {"date": "15 Jun 2025", "href": "killing-expensive-enterprise-software.html", "title": "Expensive Enterprise Software Is Dying. I Saved $70K/Month by Killing It."},
+    {"date": "5 May 2025", "href": "pacesetter-launch.html", "title": "Launching the Plains Pacesetter Step Challenge"},
+    {"date": "30 Apr 2025", "href": "deploying-python-apps-databricks.html", "title": "Deploying Python Apps on Databricks: What No One Tells You"},
+    {"date": "30 Nov 2024", "href": "killing-it-in-cs-part-2.html", "title": "Killing It in Computer Science (Part 2)"},
+    {"date": "25 Nov 2024", "href": "ai-mistakes-internship-apps.html", "title": "The Worst Ways to Use AI in Internship / Job Apps"},
+    {"date": "20 Nov 2024", "href": "internships-hard-to-get.html", "title": "Internships Are Hard to Get, These Tips Might Help"},
+    {"date": "15 Nov 2024", "href": "three-best-strategies-cs-degree.html", "title": "Three Strategies for Killing a CS Degree"},
+]
+
+PLACEHOLDER = '<!--#include related-posts -->'
+RELATED_RE = re.compile(r'<section class="keep-reading">[\s\S]*?</section>', re.MULTILINE)
+POSTS_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', 'posts'))
+
+
+def pick_related(current_href):
+    idx = next((i for i, p in enumerate(POSTS) if p["href"] == current_href), None)
+    others = [p for p in POSTS if p["href"] != current_href]
+    if len(others) <= 3:
+        return others
+    if idx is None:
+        return others[:3]
+    selected = []
+    # adjacent newer post
+    if idx > 0:
+        selected.append(POSTS[idx - 1])
+    # adjacent older post
+    if idx < len(POSTS) - 1:
+        selected.append(POSTS[idx + 1])
+    # fill to 3 from the top of the list (newest first), skip already picked
+    picked_hrefs = {p["href"] for p in selected}
+    for p in POSTS:
+        if len(selected) >= 3:
+            break
+        if p["href"] != current_href and p["href"] not in picked_hrefs:
+            selected.append(p)
+            picked_hrefs.add(p["href"])
+    return selected
+
+
+def build_related_html(current_href):
+    related = pick_related(current_href)
+    items = "\n".join(
+        f'    <li><time>{p["date"]}</time> <a href="{p["href"]}">{p["title"]}</a></li>'
+        for p in related
+    )
+    return (
+        '<section class="keep-reading">\n'
+        '<h2>&#9658; Keep Reading</h2>\n'
+        '<ul>\n'
+        f'{items}\n'
+        '</ul>\n'
+        '</section>'
+    )
+
+
+for fname in os.listdir(POSTS_DIR):
+    if not fname.endswith('.html'):
+        continue
+
+    path = os.path.join(POSTS_DIR, fname)
+    with open(path, 'r', encoding='utf-8') as fh:
+        content = fh.read()
+
+    related_html = build_related_html(fname)
+
+    if PLACEHOLDER in content:
+        new_content = content.replace(PLACEHOLDER, related_html)
+    elif RELATED_RE.search(content):
+        new_content = RELATED_RE.sub(related_html, content, count=1)
+    else:
+        new_content = content.replace('</article>', related_html + '\n</article>', 1)
+
+    if new_content != content:
+        with open(path, 'w', encoding='utf-8') as fh:
+            fh.write(new_content)


### PR DESCRIPTION
## Summary
This PR adds an automated system to inject a "Keep Reading" section at the end of each blog post, displaying 3 related posts selected intelligently based on chronological proximity and recency.

## Key Changes

- **New script `scripts/inject_related_posts.py`**: Automates the injection of related posts sections into all blog post HTML files
  - Maintains a curated list of 10 blog posts with metadata (date, href, title)
  - Implements smart selection algorithm that prioritizes adjacent posts (newer/older) and fills remaining slots from the newest posts
  - Supports three injection methods: placeholder replacement, regex-based section replacement, or insertion before `</article>` tag
  - Runs as part of the build pipeline

- **Styling for `.keep-reading` section**:
  - Added retro terminal-style CSS in `assets/css/style.css` with navy background, yellow text, and ridge border
  - Added modern glassmorphism-style overrides in `assets/css/modern-style.css` with backdrop blur, subtle borders, and smooth hover transitions
  - Includes responsive styling for dates, links, and hover states

- **Applied to all blog posts**: Related posts sections automatically injected into 10 existing blog post files

- **Build pipeline integration**: Added step to `build.yml` to run the injection script after the main build

## Implementation Details

The selection algorithm ensures variety by:
1. Always including the chronologically adjacent newer post (if exists)
2. Always including the chronologically adjacent older post (if exists)  
3. Filling remaining slots (up to 3 total) from the newest posts first, skipping already-selected posts

This provides readers with contextually relevant navigation while maintaining a consistent "Keep Reading" experience across all posts.

https://claude.ai/code/session_01U9gBpHRkbGmnWJDUXYzuNo