### PR TITLE
Rework Flightless ramp: real track physics, adjustable shape, gate catapult

### DIFF
--- a/pages/flightless.html
+++ b/pages/flightless.html
@@ -115,6 +115,14 @@
   .shop-foot{ display:flex; align-items:center; justify-content:center; gap:4px 22px; flex-wrap:wrap; }
   .shop-foot .big-btn{ margin:0; padding:10px 44px; font-size:18px; }
   .shop-foot .notes{ display:flex; flex-direction:column; gap:2px; align-items:flex-start; }
+  .ramp-shape{
+    display:flex; flex-direction:column; gap:2px;
+    font-size:11px; color:var(--muted);
+    background:var(--panel); border:2px solid var(--border); padding:6px 10px;
+  }
+  .ramp-shape label{ color:var(--text); font-size:12px; }
+  .ramp-shape b{ color:var(--yellow); }
+  .ramp-shape input[type=range]{ width:170px; accent-color:var(--yellow); cursor:pointer; }
   .shop-foot .small-note{ margin:0; text-align:left; }
   .shop-foot .reset-link{ margin:0; width:auto; text-align:left; }
   h1.game-title{
@@ -305,6 +313,11 @@
       <div class="shop-grid" id="gear-grid"></div>
     </div>
     <div class="shop-foot">
+      <div class="ramp-shape">
+        <label>&#127934; Ramp nose: <b id="nose-val">20&deg;</b></label>
+        <input type="range" id="nose-slider" min="0" max="32" step="1" value="20">
+        <span>flat = raw speed &middot; steep = launch height</span>
+      </div>
       <button class="big-btn" id="launch-btn">&#128640; Launch</button>
       <div class="notes">
         <p class="small-note">&#8679;/&#8681; or W/S steer &middot; SPACE rocket &middot; X afterburner &middot; C fire cannon &middot; F fast-forward &middot; ENTER launch</p>
@@ -366,6 +379,7 @@ const defaultState = () => ({
   money:0, day:1, lvl:{ramp:0,aero:0,wings:0,rocket:0,fuel:0,sling:0,bounce:0,sponsor:0,gun:0,struts:0},
   perm:{speedo:false,alti:false,burner:false,tank:false},
   best:{dist:0,alt:0,spd:0}, claimed:[], won:false, muted:false, started:false,
+  rampNose:20,
 });
 let state = defaultState();
 try{
@@ -384,9 +398,10 @@ function save(){ try{ localStorage.setItem(SAVE_KEY, JSON.stringify(state)); }ca
 
 /* ════════════════ upgrades ════════════════ */
 const UPGRADES = [
-  { id:'ramp',    icon:'\u{1F6DD}', name:'Ramp Height',  base:15,  mul:1.55, max:12, unlock:0,
-    desc:'A taller ramp means a faster launch.',
-    val:l=>`${derive({ramp:l}).rampH.toFixed(0)} m tall` },
+  { id:'ramp',    icon:'\u{1F6DD}', name:'Ramp Track',   base:15,  mul:1.55, max:12, unlock:0,
+    desc:'More track to build speed on. Tune the nose with the shape slider below.',
+    val:l=>{ const d=derive({ramp:l});
+             return `${Math.round(d.rampLen)} m · ${Math.round(d.rampH)} m drop · ~${Math.round(d.rampExitV)} m/s exit`; } },
   { id:'wings',   icon:'\u{1FABD}', name:'Glider Wings', base:25,  mul:1.55, max:10, unlock:0,
     desc:'More lift, flatter glide. Ease off "up" to cruise.',
     val:l=>{ if(l===0) return 'no wings'; const d=derive({wings:l});
@@ -409,9 +424,9 @@ const UPGRADES = [
   { id:'sponsor', icon:'\u{1F4B0}', name:'Sponsor Deal', base:250, mul:1.55, max:6, unlock:250,
     desc:'Fish Co. multiplies your earnings on every flight.',
     val:l=>`×${(1+0.35*l).toFixed(2)} cash earned` },
-  { id:'sling',   icon:'\u{1F3AF}', name:'Launcher',     base:400, mul:1.55, max:8, unlock:500,
-    desc:"An elastic slingshot at the ramp's lip. Extra launch speed.",
-    val:l=> l===0 ? 'not installed' : `+${15*l} m/s boost` },
+  { id:'sling',   icon:'\u{1F3AF}', name:'Catapult',     base:400, mul:1.55, max:8, unlock:500,
+    desc:'An elastic winch flings you from the gate at the top of the track.',
+    val:l=> l===0 ? 'not installed' : `+${20*l} m/s at the gate` },
   { id:'gun',     icon:'\u{1F52B}', name:'Sky Cannon',   base:3000, mul:1.7,  max:6, unlock:2500,
     desc:'Press C to blast obstacles out of the sky. Upgrade for range and bigger targets.',
     val:l=>{ if(l===0) return 'not installed';
@@ -441,16 +456,30 @@ function derive(over){
   const cd0w  = 0.008;                                    // clean-wing profile drag coeff
   const k     = 1/(Math.PI*ar*0.85);                      // induced drag factor (e = 0.85)
   const cd0eff = cdA/wingS + cd0w;
+  // ramp geometry: upgrades buy track length; the player-set nose angle
+  // shapes the whole arc (entry is a fixed steep -84° drop), so drop height
+  // and exit speed both fall out of length + shape
+  const rampLen = 16 + 11*L.ramp + 1.2*L.ramp*L.ramp;
+  const rampNose = clamp(state.rampNose===undefined ? 20 : state.rampNose, 0, 32)*RAD;
+  const rampTh0 = -84*RAD;
+  const rampR = rampLen/(rampNose-rampTh0);
+  const rampH = rampR*(Math.cos(rampNose)-Math.cos(rampTh0));
+  const mu = Math.max(0.008, 0.02 - 0.0012*L.aero);
+  const sling = L.sling * 20;
+  const rampV0 = 2 + sling;
+  // exact energy along the arc: gravity gain minus friction ∫μg·cosθ·R dθ
+  const rampExitV = Math.sqrt(Math.max(1,
+    rampV0*rampV0 + 2*9.81*rampH - 2*mu*9.81*rampR*(Math.sin(rampNose)-Math.sin(rampTh0))));
   return {
     mass, wingS, ar, cdA, cd0w, k,
     clSlope: 2*Math.PI*ar/(ar+2),                         // finite-wing lift slope, /rad
-    rampH:  4 + 3*L.ramp + 0.5*L.ramp*L.ramp,
-    mu:     Math.max(0.02, 0.05 - 0.003*L.aero),
+    rampLen, rampNose, rampH, rampExitV, rampV0,
+    mu,
     wingAuth: wings===0 ? 1.5 : 2.4 + 0.35*wings,         // pitch authority rad/s
     gMax:   4 + 0.9*L.struts,                             // structural load limit, g
     thrust: L.rocket ? 10 + 8*L.rocket : 0,
     fuelMax:L.rocket ? 2 + 1.3*L.fuel : 0,
-    sling:  L.sling * 15,
+    sling,
     rest:   L.bounce ? 0.12 + 0.09*L.bounce : 0,
     mult:   1 + 0.35*L.sponsor,
     gunLevel: L.gun,
@@ -674,9 +703,9 @@ let run = null;               // per-run mutable state
 let particles = [];
 let timeSim = 0;
 
-function buildRamp(H){
-  const th0 = -78*RAD, th1 = 12*RAD;
-  const R = H / (Math.cos(th1) - Math.cos(th0));   // radius so total drop = H
+function buildRamp(len, th1){
+  const th0 = -84*RAD;                             // fixed steep entry drop
+  const R = len/(th1-th0);                         // radius so the arc is `len` long
   const pts = [];
   const N = 48;
   for(let i=0;i<=N;i++){
@@ -690,7 +719,7 @@ function buildRamp(H){
   const cum = [0];
   for(let i=1;i<pts.length;i++)
     cum.push(cum[i-1] + Math.hypot(pts[i].x-pts[i-1].x, pts[i].y-pts[i-1].y));
-  return { pts, cum, len:cum[cum.length-1], exitTh:th1 };
+  return { pts, cum, len:cum[cum.length-1], exitTh:th1, H:R*(Math.cos(th1)-Math.cos(th0)) };
 }
 function rampPoint(s){
   const {pts, cum} = ramp;
@@ -703,15 +732,15 @@ function rampPoint(s){
 
 function newRun(){
   st = derive();
-  ramp = buildRamp(st.rampH);
+  ramp = buildRamp(st.rampLen, st.rampNose);
   const start = rampPoint(0);
   run = {
     x:start.x, y:start.y, vx:0, vy:0,
-    head:start.th, rampS:0, rampV:0.5,
+    head:start.th, rampS:0, rampV:st.rampV0,
     fuel:st.fuelMax, sliding:false, done:false,
     dist:0, maxAlt:0, maxSpd:0, t:0,          // records only count once airborne
     thrusting:false, tumble:0, stalled:false,
-    burnerUsed:false, tankUsed:false, slingRemaining:0,
+    burnerUsed:false, tankUsed:false,
     trail:[], trailT:0,
     collected:new Set(), coinCash:0, coinCount:0, starCash:0, starCount:0,
     obGone:new Set(), gunCash:0, gunKills:0, gunCooldown:0,
@@ -806,9 +835,12 @@ function trackProgress(){
 
 function stepRamp(h){
   const th = rampPoint(run.rampS).th;
-  const accS = -G*Math.sin(th) - st.mu*G*Math.cos(th);
+  // waxed track: gravity along the slope, a whisper of friction, air drag
+  const accS = -G*Math.sin(th) - st.mu*G*Math.cos(th)
+             - 0.5*RHO0*run.rampV*run.rampV*st.cdA/st.mass;
   run.rampV = Math.max(0.3, run.rampV + accS*h);
   run.rampS += run.rampV*h;
+  if(Math.random() < h*run.rampV*1.5) burst(run.x, run.y+0.2, 1, '#e8f6ff', 2);
   if(run.rampS >= ramp.len){
     const over = run.rampS - ramp.len;
     const lip = rampPoint(ramp.len);
@@ -816,10 +848,9 @@ function stepRamp(h){
     run.vx = Math.cos(ramp.exitTh)*run.rampV;
     run.vy = Math.sin(ramp.exitTh)*run.rampV;
     phase = 'flight';
-    run.slingRemaining = st.sling;   // applied over ~0.2 s in stepFlight
-    cam.shake = Math.min(14, 4 + st.sling*0.08);
+    cam.shake = Math.min(12, 2 + run.rampV*0.05);
     SFX.launch();
-    if(st.sling>0) popup(`LAUNCHER +${st.sling} m/s!`, 26);
+    popup(`LIFTOFF — ${Math.round(run.rampV)} m/s!`, 22);
     burst(run.x, run.y, 18, '#ffe066', 8);
     // hand this substep's leftover time to the flight integrator so the
     // transition neither drops nor double-counts a slice of time
@@ -838,15 +869,6 @@ function stepFlight(h){
   run.gunCooldown = Math.max(0, run.gunCooldown - h);
   const rhoN = Math.exp(-run.y/SCALE_H);   // 1 at sea level
   const rho = RHO0*rhoN;
-
-  if(run.slingRemaining > 0){
-    // spread the launcher's kick over ~0.2 s so the camera eases into the
-    // new speed instead of snapping on a single-frame velocity jump
-    const kick = Math.min(run.slingRemaining, (st.sling/0.2)*h);
-    run.vx += Math.cos(run.head)*kick;
-    run.vy += Math.sin(run.head)*kick;
-    run.slingRemaining -= kick;
-  }
 
   if(run.sliding){
     // grinding along the ice: snow friction + aerodynamic drag
@@ -1060,8 +1082,8 @@ function draw(dtReal){
 
   let tz, tx, ty;
   if(phase==='shop'){
-    tz = clamp(300/(st.rampH+14), 1.5, 8);
-    tx = -ramp.len*0.28; ty = st.rampH*0.32;
+    tz = clamp(320/(ramp.H+16), 1.2, 8);
+    tx = -ramp.len*0.28; ty = ramp.H*0.32;
   } else {
     tz = clamp(1200/(80 + 2.0*spCam + 0.32*p.y), 0.8, 9);
     tx = p.x + cam.vxS*0.35;
@@ -1358,11 +1380,21 @@ function drawObstacles(){
 function drawRamp(){
   if(!ramp) return;
   const pts = ramp.pts;
-  // support struts
+  // support struts with diagonal cross-bracing
   ctx.strokeStyle = '#7a4a21'; ctx.lineWidth = Math.max(1.5, cam.z*0.35);
   for(let i=0;i<pts.length;i+=6){
     const sx = w2sX(pts[i].x);
     ctx.beginPath(); ctx.moveTo(sx, w2sY(pts[i].y)); ctx.lineTo(sx, w2sY(0)); ctx.stroke();
+  }
+  ctx.strokeStyle = 'rgba(122,74,33,0.65)'; ctx.lineWidth = Math.max(1, cam.z*0.2);
+  for(let i=0;i+6<pts.length;i+=6){
+    const a = pts[i], b = pts[i+6];
+    ctx.beginPath();
+    ctx.moveTo(w2sX(a.x), w2sY(a.y*0.55));
+    ctx.lineTo(w2sX(b.x), w2sY(b.y));
+    ctx.moveTo(w2sX(a.x), w2sY(a.y*0.55));
+    ctx.lineTo(w2sX(b.x), w2sY(b.y*0.5));
+    ctx.stroke();
   }
   // track
   ctx.strokeStyle = '#a0622d'; ctx.lineWidth = Math.max(3, cam.z*0.7);
@@ -1494,7 +1526,21 @@ const victoryEl = document.getElementById('victory');
 const shopGrid = document.getElementById('shop-grid');
 const gearGrid = document.getElementById('gear-grid');
 
+// ramp shape slider: drag to reshape the whole arc, live-previewed behind
+// the shop; the card numbers refresh once the drag settles
+const noseSlider = document.getElementById('nose-slider');
+const noseVal = document.getElementById('nose-val');
+noseSlider.addEventListener('input', () => {
+  state.rampNose = +noseSlider.value;
+  noseVal.textContent = state.rampNose + '°';
+  st = derive();
+  ramp = buildRamp(st.rampLen, st.rampNose);
+});
+noseSlider.addEventListener('change', () => { save(); renderShop(); });
+
 function renderShop(){
+  noseSlider.value = state.rampNose;
+  noseVal.textContent = state.rampNose + '°';
   document.getElementById('shop-money').textContent = fmtCash(state.money);
   document.getElementById('shop-day').textContent = state.day;
   document.getElementById('shop-best').textContent = fmtDist(state.best.dist);
@@ -1544,7 +1590,7 @@ function renderShop(){
       SFX.buy();
       save();
       renderShop();
-      st = derive(); ramp = buildRamp(st.rampH);   // live-preview taller ramp behind the shop
+      st = derive(); ramp = buildRamp(st.rampLen, st.rampNose);   // live-preview taller ramp behind the shop
     });
     shopGrid.appendChild(card);
   }
@@ -1713,7 +1759,7 @@ function openShop(){
   phase = 'shop';
   run = null;
   st = derive();
-  ramp = buildRamp(st.rampH);
+  ramp = buildRamp(st.rampLen, st.rampNose);
   renderShop();
   shopEl.classList.add('show');
 }
@@ -1725,6 +1771,13 @@ function startLaunch(){
   shopEl.classList.remove('show');
   newRun();
   phase = 'ramp';
+  if(st.sling > 0){
+    popup(`\u{1F3AF} CATAPULT +${st.sling} m/s!`, 24);
+    SFX.boom();
+    cam.shake = Math.min(12, 4 + st.sling*0.04);
+    const p0 = rampPoint(0);
+    burst(p0.x, p0.y, 14, '#ffe066', 7, p0.th);
+  }
   hudEl.style.display = 'flex';
   ffBtn.style.display = 'block';
   touchEl.classList.add('flying');
@@ -1766,7 +1819,7 @@ function loop(now){
   if(phase==='flight' && run){
     scale = input.ff ? 3 : (run.sliding ? 2.5 : 2.4);
   } else if(phase==='ramp' && ramp){
-    scale = clamp(ramp.len/60, 1, 3);
+    scale = clamp(1.8 + ramp.len/150, 1.8, 3.2);
   }
   const dt = dtReal*scale;
 
@@ -1791,7 +1844,7 @@ function loop(now){
 
 // boot: first-ever visit goes straight to the ramp, no shop
 st = derive();
-ramp = buildRamp(st.rampH);
+ramp = buildRamp(st.rampLen, st.rampNose);
 if(!state.started){
   phase = 'shop';           // idle camera on the ramp behind the intro
   introEl.classList.add('show');


### PR DESCRIPTION
Follow-up to #136 addressing ramp feedback.

- **Adjustable ramp shape from day 1**: new nose-angle slider (0–32°) in the shop reshapes the whole arc live — flat = raw speed, steep = launch height. Entry drop steepened to -84°, default nose 20°.
- **Ramp upgrades buy track length** with faster (quadratic) scaling; the card shows track length, drop height and predicted exit speed from the exact energy balance along the arc.
- **Faster, slipperier track**: base friction 0.05 → 0.02, air drag now applies on the track, small push off the gate, and the ramp phase runs at flight-like time scale.
- **Launcher → Catapult**: instead of an unexplained velocity kick at the lip, it flings you from the gate at the top of the track (+20 m/s per level) and the speed carries down the ramp physically. Liftoff popup shows your real exit speed.
- Ramp gets diagonal cross-bracing; old saves migrate cleanly (default 20° nose).

Verified with scripted headless-Chromium flights: fresh save, mid-game catapult save, slider persistence — no JS errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P1gc15kybJVrnPJpFoMmtC

---
_Generated by [Claude Code](https://claude.ai/code/session_01P1gc15kybJVrnPJpFoMmtC)_