### PR TITLE
Flightless: rework roadmap + per-component improvement pass

### DIFF
--- a/FLIGHTLESS_ROADMAP.md
+++ b/FLIGHTLESS_ROADMAP.md
@@ -1,10 +1,18 @@
 # Flightless Roadmap
 
 Flightless is a Learn-to-Fly-style launch game at `pages/flightless.html`. The
-sim is split into ES modules under `assets/js/flightless-*.js`. This doc is a
-backlog of discrete, independently-startable jobs — bug fixes, rebalancing,
-and new content — organized so a swarm of agents can each pick one up without
-stepping on each other.
+sim is split into ES-module factories under `assets/js/flightless-*.js`, wired
+together by the orchestrator in the HTML. This doc is both a **backlog** of
+discrete jobs and a **per-component improvement charter** so a swarm of agents —
+one per module — can each own a file and improve it in parallel without
+colliding.
+
+> **This revision (rewrite):** corrected the P0 diagnoses against the actual
+> code, merged the Wall bugs that are really one problem, added a
+> **Shared invariants** contract every parallel agent must honor, and added a
+> **per-component charter** (§B) that maps every module to a concrete,
+> self-contained slate of work. The original cross-cutting backlog is preserved
+> and tightened in §C.
 
 ## Module map (know this before picking a job)
 
@@ -21,130 +29,271 @@ stepping on each other.
 | `assets/js/flightless-results.js` | End-of-flight scoring, results screen |
 | `pages/flightless.html` | Orchestrator: the shared `sim` object, module wiring, boot, main loop |
 
-**Working conventions:**
-- Each module is a `createXxx(deps)` factory — read `flightless-store.js` first, it's the cleanest example of the pattern.
-- `sim.phase`/`sim.run`/`sim.ramp`/`sim.st`/`sim.particles`/`sim.speedLines`/`sim.timeSim`/`sim.W`/`sim.Hpx` are the shared mutable simulation state — read/write through `sim.x`, never take a local copy.
-- `state` is the save-data object — always mutate it in place (`state.foo = x`), never reassign the variable, since every module holds its own reference from construction time.
-- If a job needs a NEW cross-module function that doesn't exist yet, wire it through `pages/flightless.html`'s `bridge`/`call()` mechanism the same way `popup`/`burst`/`finishRun` are — don't invent a second wiring pattern.
-- Jobs marked **(file: new)** create their own module — low collision risk, safe to parallelize aggressively.
-- Jobs marked **(file: shared)** touch a file another job might also touch — coordinate or take them sequentially.
+---
 
-Size guide: **S** = an hour or two, **M** = a focused session, **L** = multi-session, **XL** = its own mini-project.
+## Shared invariants — READ FIRST, every agent honors these
+
+These are the contracts that let ten agents edit ten files at once without
+breaking each other. **Do not violate them even if your file's job seems to
+want to.**
+
+1. **Factory signatures are frozen.** Every module is a `createXxx(deps)` that
+   returns an object. You may *add* new methods/exports to your return object,
+   but never rename or remove an existing one, and never change what `deps`
+   fields you consume without the orchestrator agent also wiring them. Read
+   `flightless-store.js` first — it's the cleanest example of the pattern.
+2. **`sim.*` is shared mutable sim state** (`phase`/`run`/`ramp`/`st`/
+   `particles`/`speedLines`/`timeSim`/`W`/`Hpx`/`DPR`). Read/write through
+   `sim.x`; never take a local copy. You may **add new properties** to `sim`
+   (see the reserved list below) but never rename existing ones.
+3. **`state` is the save object.** Mutate in place (`state.foo = x`), never
+   reassign the variable — every module holds its own reference from
+   construction. **Only `flightless-save.js` may add fields to `defaultState()`.**
+   Every other module that wants a new persistent field must read it
+   defensively (`state.foo ?? fallback`) so it works on saves written before
+   the field existed.
+4. **The `run` object is owned by `flightless-physics.js`** (`newRun()`).
+   Only physics adds fields to it. Other modules read `sim.run.*`. If
+   `flightless-data.js` wants a new contract, it must be expressible from an
+   **existing** `run` field (see the list in §B-data).
+5. **New cross-module calls go through the `bridge`/`call()` mechanism** in the
+   HTML the same way `popup`/`burst`/`finishRun` do — don't invent a second
+   wiring pattern. If your job needs a genuinely new cross-module function, it's
+   a **coordinated** job (flag it; the orchestrator agent wires it).
+6. **Reserved shared properties** (agents may rely on these existing; whoever
+   writes one, the others read defensively):
+   - `sim.paused` (boolean) — set by hud-input, honored by the HTML main loop.
+   - `state.musicMuted`, `state.settings`, `state.ngPlus` — added to defaults by
+     save.js; consumed defensively elsewhere.
+7. **Determinism stays deterministic.** Anything placed along the flight path
+   (collectibles/obstacles/rings/weather) uses `hash01(cellIndex…)`, never
+   `Math.random()`, so it's identical every run at a given distance/day.
+   `Math.random()` is fine for transient VFX only.
+8. **The fixed-timestep sim must stay deterministic and allocation-light.** No
+   per-step heap churn in `stepFlight`/`stepRamp`; VFX allocations belong in the
+   render/particle layer.
+9. **Playtest your change.** Open `pages/flightless.html`, launch a flight, and
+   confirm you didn't throw a console error or break the boot sequence.
 
 ---
 
-## P0 — Critical fixes (do these first)
+## A. Critical fixes (P0 — do these first, they gate the fun)
 
-1. **Fix the Wall's unwinnable hitbox.** `LANDMARKS.wall.h = 1300` in `flightless-data.js`, but altitude-farming (`cashAlt = maxAlt*0.3` in `flightless-results.js`) actively rewards climbing well past that, and a maxed rocket (`flightless-physics.js` `derive()`, `thrust: 10+8*L.rocket`) blows through 1300m almost immediately off the ramp. Endgame flight paths never intersect the Wall's collision band. Fix by raising the collision height substantially (or rethinking the check in `checkLandmarks()` in `flightless-world.js` to not gate on altitude at all — e.g. treat it as a full-height barrier), and playtest that a well-upgraded flight can actually connect. **(file: shared — data.js + world.js)** — **S/M**
-2. **Let one flight deal more than one hit.** `checkLandmarks()` knocks the player backward out of the landmark's x-band on every hit, so realistically only one hit connects per flight against a 12,000 HP wall. Either soften the knockback so skilled players can grind multiple hits in one pass, or rework landmark damage into a "ram it and take an HP-vs-your-speed comparison" resolution instead of the current bounce-off. **(file: `flightless-world.js`)** — **M**
-3. **Rebalance the late-game cash curve.** The final milestone (`MILESTONES` in `flightless-data.js`, `[35000, 100000]`) pays out enough to max the whole upgrade tree in a couple of flights, which is why the game "solves itself" the moment the rocket unlocks. Spread this payout across more/smaller milestones, or gate it behind actually destroying the Wall instead of just reaching its distance. **(file: `flightless-data.js`)** — **S**
-4. **Add a "why didn't that work" signal.** When a flight passes near/through the Wall's x-band without dealing damage (wrong altitude, already destroyed, etc.), there's no feedback — it just silently does nothing. Add a popup/SFX cue ("flew over the Wall — dive lower!") so players can course-correct instead of being confused. Depends on job 1 landing first so the guidance matches the real mechanic. **(file: `flightless-world.js`)** — **S**
-
----
-
-## Gameplay mechanics & balance
-
-5. **Weather system.** Daily wind (headwind/tailwind/crosswind) that shifts the effective glide angle and drag; visualize with streaked cloud motion. New `flightless-weather.js` module, hooked into `stepFlight()` via an injected wind-force term. **(file: new)** — **L**
-6. **Daily modifiers.** Each day rolls a flavor modifier shown in the shop ("Ice Day: −20% ramp friction", "Gusty: obstacles drift sideways", "Bounty Day: ×2 obstacle cash"). Reuses the existing deterministic-per-day hashing already used for contracts (`contractsFor()` in `flightless-data.js`) — same pattern, new table. **(file: `flightless-data.js` + `flightless-physics.js` hook)** — **M**
-7. **Real stakes / a fail state.** Right now every flight "succeeds," just with less money — there's no tension. Consider a light risk mechanic: a "sponsor patience" meter that drops on bad flights and unlocks a bonus if kept full, or a hard-mode toggle where big obstacle hits cost cash instead of just a speed penalty. **(file: `flightless-results.js` + `flightless-world.js`)** — **M**
-8. **Multi-hit combo unification.** Fish/star/ring combos currently share one `combo`/`comboT` counter in `flightless-world.js`; extend the combo chain to also count obstacle kills and landmark hits so a single "flow state" run feels more connected. **(file: `flightless-world.js`)** — **S**
-9. **Weekly boss flight event.** A special one-per-week flight with a unique modifier set and a large one-time reward, tracked in save state (`state.lastBossWeek` or similar). Good candidate for a fully new module. **(file: new)** — **L**
-10. **Style-based contracts.** Extend `CONTRACT_POOL` in `flightless-data.js` beyond quantity targets ("catch 5 fish") to style targets ("land 3 bounces in a row without sliding", "stay under 50m altitude for the whole flight"). Needs new tracking fields on `run` in `flightless-physics.js`'s `newRun()`. **(file: `flightless-data.js` + `flightless-physics.js`)** — **M**
-11. **Rebalance pass on upgrade cost curves.** All upgrades currently use the same `base * mul^level` shape (`upgCost()` in `flightless-data.js`) with `mul` mostly 1.55 — a full economic pass (spreadsheet the cost-vs-payout curve for each upgrade line, tune outliers) would smooth out the "everything trivial after rocket" problem more holistically than any single numeric tweak. **(file: `flightless-data.js`)** — **M**
-12. **Fuel/energy risk-reward.** Currently fuel just runs out and stops thrust. Consider an overheat mechanic for sustained afterburner-style play, or a "coast on fumes" bonus for landing with exactly 0 fuel. **(file: `flightless-physics.js`)** — **S**
-
----
-
-## New mechanics
-
-13. **Biome progression.** Segment the 35km flight into visually and mechanically distinct zones — Ice Sheet (0–2.5km) → Open Ocean (2.5–10km, water hazards/sharks) → Cloud Layer (10–20km, turbulence) → Stratosphere (20–35km, thin air, needs a new "pressure suit" upgrade to avoid a speed/control penalty). Touches `flightless-render.js` (backdrop per zone) and `flightless-physics.js` (per-zone force modifiers). **(file: shared — render.js + physics.js + new data)** — **XL**
-14. **Drafting/formation flying.** Flying close behind a flock of birds (existing obstacle type) gives a drag-reduction bonus instead of just being a collision hazard — rewards precision flying instead of only avoidance. **(file: `flightless-world.js` + `flightless-physics.js`)** — **M**
-15. **Fuel/boost pickups.** Floating balloon-like pickups (reuse the existing ring visual language) that refill fuel or grant a temporary speed boost, placed with the same deterministic-cell trick as coins/stars. **(file: `flightless-world.js` + `flightless-render.js`)** — **M**
-16. **Cargo/passenger mode.** An optional "carry a chick" toggle before launch — bonus cash multiplier, but g-limit and stall margins are tighter. Adds a build-around choice, not just power creep. **(file: `flightless-physics.js` + `flightless-store.js`)** — **M**
-17. **Night flights.** Every Nth day is a night flight — reduced draw distance, aurora backdrop, glow-in-the-dark collectibles worth more. Mostly a `flightless-render.js` reskin plus a small `flightless-world.js` value tweak. **(file: shared)** — **M**
-18. **New landmark bosses.** The Wall is currently the only "real" boss; add 2–3 more with unique mechanics beyond "fly into it" — e.g. a moving iceberg that drifts along the x-axis, or a wave of penguin rivals you have to out-glide. Extend `LANDMARKS` and `checkLandmarks()`. **(file: `flightless-data.js` + `flightless-world.js`)** — **L**
-19. **Post-Wall endgame content.** Right now beating the Wall just shows a "keep flying" screen. Add a second, harder wall/void at 2× distance, or a New Game+ with permanently harder obstacles and better rewards, so there's a reason to keep playing after the current win condition. **(file: `flightless-data.js` + `pages/flightless.html` victory flow)** — **L**
-20. **Ghost replay.** Record your best flight's trail (`run.trail` already exists in `flightless-physics.js`) and render a translucent ghost penguin following that exact path on your next attempt, for a tight feedback loop on improving a line. **(file: `flightless-render.js` + `flightless-save.js`)** — **M**
-
----
-
-## Upgrades & progression content
-
-21. **Mk2 upgrade tier.** Once a player maxes an upgrade line, unlock a "Mk2" version with a new effect curve, gated behind a prestige resource (spend BP or a new currency). Extends `UPGRADES` in `flightless-data.js` with a `next` pointer to a follow-on upgrade definition. **(file: `flightless-data.js`)** — **L**
-22. **Cosmetic-only unlocks.** Penguin skins/hats, ramp skins, trail colors — unlocked by medals, zero power effect, pure collection goal. New `COSMETICS` table plus a picker UI in the shop. **(file: `flightless-data.js` + `flightless-store.js` + `flightless-render.js`)** — **L**
-23. **New gear items.** Parachute (guarantees a soft landing once per flight), Radar (obstacles render before they're normally visible), GPS Compass (shows distance-to-next-milestone in the HUD). Extends `GEAR` in `flightless-data.js`. **(file: `flightless-data.js` + relevant module per item)** — **M each**
-24. **Branching talent choice.** At a few key unlock points, let the player choose between two mutually exclusive upgrade paths (e.g. "Speed Demon" vs "High Flyer" wing variants) instead of one linear line — adds replay variety across resets. **(file: `flightless-data.js`)** — **L**
-25. **Rotating daily shop deal.** One random upgrade is discounted each day, using the same per-day deterministic hash already used elsewhere. Small, high-value addition to the shop's "reason to check in daily" loop. **(file: `flightless-data.js` + `flightless-store.js`)** — **S**
-26. **Bonus-shop respec.** Let players refund bonus-shop levels for a partial BP refund, in case they want to try a different permanent build. **(file: `flightless-store.js`)** — **S**
+1. **The Wall is effectively a one-hit-per-flight grind (merges old P0 #1+#2).**
+   `checkLandmarks()` (`world.js`) *does* damage the Wall whenever the penguin
+   is below `LANDMARKS.wall.h` (1300 m) inside its x-band — a glide descends
+   through that fine. The real problem is the **knockback**: every hit sets
+   `run.x = face-1` and reverses `vx`, ejecting the player from the band, so
+   only one hit lands per flight against 12 000 HP (≈6+ flights to kill even
+   maxed). **Fix:** rework landmark resolution so a fast, well-built pass can
+   deal sustained/multiple damage — e.g. soften knockback to a speed-scaled
+   *slow* instead of a reversal, or make it a "ram-through" HP-vs-speed
+   resolution where enough speed punches through and keeps going. Playtest that
+   a maxed rocket+plating build can bring the Wall down in **1–2 skilled
+   flights**, not six. **(file: `world.js`; balance numbers may pair with
+   `data.js`)** — **M**
+2. **Rebalance the late-game cash curve.** `MILESTONES` ends
+   `[35000, 100000]` and `cashDist = 6 + 2·dist^0.9` already pays ~100k+ for a
+   single 35 km flight after sponsor×airtime multipliers — so the tree maxes in
+   one or two flights the moment the rocket unlocks. Spread the final payout
+   across more, smaller milestones and/or gate the big reward behind actually
+   *destroying* the Wall rather than reaching its distance. **(file: `data.js`)**
+   — **S**
+3. **Add a "why didn't that work" signal.** When a pass crosses the Wall's
+   x-band without dealing damage (already destroyed, or — post-fix — glanced
+   off), give a popup + SFX cue so the player can course-correct instead of
+   being silently confused. Land this *after* #1 so the guidance matches the
+   real mechanic. **(file: `world.js`)** — **S**
+4. **Kill the dead `WIN_DIST` export or make it load-bearing.** `WIN_DIST`
+   (`data.js`) is exported and destructured but never used — the win condition
+   is `state.lmHP.wall<=0`. Either remove it or route the victory/2×-distance
+   check through it so there's one source of truth. **(file: `data.js`)** — **S**
 
 ---
 
-## Graphics & VFX
+## B. Per-component charters (the swarm assignment)
 
-27. **Weather particle layers** (snow drift, rain streaks, aurora ribbons) reusing/extending the existing particle system in `flightless-render.js`. **(file: `flightless-render.js`)** — **M**
-28. **Landmark destruction VFX.** Currently a landmark death is one burst; give it multi-stage debris (chunks with their own simple gravity/tumble) for a real "boss kill" payoff. **(file: `flightless-render.js`)** — **M**
-29. **Speed-based screen effects.** Motion blur / chromatic aberration ramping in at very high velocity or during afterburner use, purely as canvas post-processing in `draw()`. **(file: `flightless-render.js`)** — **S/M**
-30. **Day/night lighting cycle** tied to `state.day`, shifting `skyColor()`'s palette gradually instead of the current fixed gradient. **(file: `flightless-render.js`)** — **S**
-31. **Penguin customization rendering.** Once cosmetics exist (#22), `drawPenguin()`/`drawGlider()` need to read the equipped skin and vary the draw. **(file: `flightless-render.js`)** — **M** (depends on #22)
-32. **Ramp/launch-site visual variety per biome/day modifier.** `drawRamp()` currently has one look; branch its palette/decoration off day count or biome. **(file: `flightless-render.js`)** — **S**
-33. **Animated shop background.** The shop screen is static UI over a frozen camera view; add subtle ambient motion (waddling background penguins, drifting clouds) behind the panel. **(file: `flightless-render.js` + `flightless-store.js`)** — **S**
-34. **Ramp designer visual upgrade.** The ramp-shape editor pop-over (`flightless-store.js`) is functional but bare — add shape presets (steep launch / long glide / trick ramp) as one-click buttons alongside manual dragging. **(file: `flightless-store.js`)** — **S**
+Each charter is a **self-contained slate for one agent owning one file.** Every
+item here is achievable without editing another module (touchpoints are limited
+to the reserved shared properties in the invariants). Pick the highest-impact
+items first; ship incrementally.
+
+### B-save — `flightless-save.js`
+- **Save-schema versioning (was #51).** Add an explicit `state.version` and a
+  migration-function chain, replacing the ad-hoc field-by-field patching. Future
+  schema changes append a migration instead of another special case.
+- **Seed forward-looking defaults** so other agents can consume them defensively:
+  add `musicMuted:false`, `settings:{reduceMotion:false, sfxVol:1, musicVol:1}`,
+  `ngPlus:0` to `defaultState()` and sanitize them on load.
+- **Save export/import as pure functions (was #42, core half).** Export
+  `exportSave()` → a base64/JSON string and `importSave(str)` → validated state
+  (or throws). The store agent wires the buttons; keep these dependency-free.
+- Harden sanitization (clamp numeric fields, drop unknown keys) so a hand-edited
+  or truncated save can't crash boot.
+
+### B-sound — `flightless-sound.js`
+- **Richer SFX layering (was #37).** Add an engine-hum layer that pitches with
+  speed (drive it from a `setEngine(speed)` method physics/HUD can call via the
+  existing thrust path), impact-variety by type, and a wing-flap tick. Keep all
+  existing named cues (`ding/tick/thump/boom/launch/buy/blip/setThrust`).
+- **Background music (was #35).** A lightweight looping synth bed with its own
+  gain, exposed as `startMusic()/stopMusic()/setMusicVolume(v)`, gated on
+  `state.musicMuted` (read defensively) independently of the SFX mute.
+- **Penguin bark cues (was #38).** Short procedural one-shots (`cheer()`,
+  `oof()`) for the results/milestone agents to call. Add methods only.
+
+### B-data — `flightless-data.js` (numbers & tables only — no behavior)
+- Owns P0 #2 and #4 above.
+- **Upgrade cost-curve pass (was #11).** All lines share `base·1.55^level`.
+  Spreadsheet cost-vs-payout per line and tune outliers so progression stays
+  meaningful after the rocket.
+- **Expand medals (was #49)** and **style-based contracts (was #10)** using
+  **existing** `run` fields only — available today: `maxCombo`, `bounceCount`,
+  `gunKills`, `obHits`, `skimT`, `maxAlt`, `maxSpd`, `coinCount`, `starCount`,
+  `ringCount`, `dist`. (No new `run` fields — that's physics's call.)
+- **Daily deal + daily modifier tables (was #6 data half, #25).** A new
+  deterministic-per-day table (reuse the `contractsFor()` hashing pattern) plus
+  a pure `dailyModFor(day)` / `dailyDealFor(day)` helper. Physics/store consume
+  them defensively; ship the table + helper here regardless.
+- Landmark HP/reward tuning to make P0 #1 winnable in 1–2 flights.
+
+### B-store — `flightless-store.js` (shop UI)
+- **Ramp designer presets (was #34).** One-click "steep launch / long glide /
+  trick ramp" buttons that set `state.rampShape` and `recompute()`.
+- **Shop stat projections (was #41).** Show projected distance/top-speed across
+  the next 2–3 upgrade levels, not just the immediate next — the `val()`
+  previews already exist; render a mini 2–3-step ladder.
+- **Bonus-shop respec (was #26)** and **save export/import UI (was #42 UI).**
+  Wire buttons to `save.exportSave/importSave` **if present** (`typeof` guard so
+  it degrades gracefully before the save agent lands).
+- **Rotating daily deal UI (was #25).** If `dailyDealFor` exists, show the
+  discounted upgrade with a badge.
+
+### B-physics — `flightless-physics.js` (the sim)
+- **Fuel/energy risk-reward (was #12).** An overheat penalty for sustained
+  afterburner-style thrust, and/or a "coast on fumes" bonus for landing at ~0
+  fuel. Keep it readable from the fixed-step integrator.
+- **Daily-modifier hook (was #6 sim half).** In `stepFlight`, read an optional
+  `state.dailyMod`/wind term defensively and fold it into the force sum — a
+  no-op when absent.
+- **Feel/balance pass** that smooths rocket dominance from the *derivation*
+  side (`derive()` curves) to complement data's cost pass — e.g. diminishing
+  thrust returns at high levels.
+- **New `run` tracking fields** for future style contracts (e.g.
+  `run.slideless`, `run.lowAltTime`) — add them in `newRun()` and maintain them;
+  data can adopt them next revision. Additive only.
+
+### B-world — `flightless-world.js` (highest impact: owns P0 #1 & #3)
+- **Landmark multi-hit rework (P0 #1)** and **"flew over / glanced off" feedback
+  (P0 #3).**
+- **Combo unification (was #8).** Feed obstacle gun-kills and landmark hits into
+  the same `combo`/`comboT` chain so a hot streak feels connected. Raise or
+  retune the ×3 cap if it helps.
+- **Fuel/boost pickups (was #15).** Balloon-style pickups on the deterministic
+  cell grid that refill fuel or grant a short speed boost. Placement logic here;
+  the render agent draws them from your exported `*Pos()` + cell constants (add
+  them to the return object so render can pick them up next revision).
+- **Drafting bonus (was #14).** Flying just behind a bird flock grants a
+  drag-reduction window instead of only being a hazard (expose it as a factor on
+  `sim.run` physics reads defensively).
+
+### B-render — `flightless-render.js` (canvas; large but isolated)
+- **Speed/afterburner screen effects (was #29)**, **day/night lighting tied to
+  `state.day` (was #30)**, **multi-stage landmark destruction debris (was #28)**,
+  **ramp/launch-site variety by day (was #32)**, **animated shop background
+  (was #33)**.
+- **Weather particle layers (was #27)** as a reusable extension of the particle
+  system (snow drift / aurora), drawn defensively off any `state.dailyMod`.
+- **Reduced-motion (was #46 render half).** Respect
+  `matchMedia('(prefers-reduced-motion)')` **and** `state.settings.reduceMotion`
+  (read defensively) to damp camera shake and particle density.
+
+### B-hud-input — `flightless-hud-input.js`
+- **Pause (was #44).** A dedicated key/button that toggles `sim.paused`; the
+  HTML loop honors it (coordinated via the reserved property — you set it, they
+  read it).
+- **Fix touch/keyboard hint mismatch.** The hint text names SPACE/C even on
+  touch devices — branch on `matchMedia('(pointer:coarse)')`.
+- **Mobile refinement (was #45).** Optional drag-to-steer gesture and haptics
+  (`navigator.vibrate`) on landings/impacts.
+- **Contextual onboarding hints (was #40).** First pull-up / first stall / first
+  bounce call-outs, driven off `sim.run` state you already read.
+
+### B-results — `flightless-results.js`
+- **Expand headline flavor (was #54).** The 5 tiers repeat fast; add variety per
+  tier (pick deterministically by `state.day` so a given day reads consistently).
+- **Real stakes / sponsor-patience meter (was #7, results half).** A meter that
+  drops on weak flights and pays a bonus when kept full — pure scoring + a
+  results row; persist via a `state.*` field you read defensively (save agent
+  seeds it).
+- Call the new sound barks (`SFX.cheer/oof`) on records/medals **if present**.
+
+### B-html — `pages/flightless.html` (orchestrator)
+- **Honor `sim.paused`** in the main loop (freeze stepping without losing state).
+- **Post-Wall endgame / NG+ (was #19).** After the Wall falls, offer a second
+  harder wall at 2× distance or a New Game+ (`state.ngPlus`, seeded by save) with
+  tougher obstacles and better rewards, so there's a reason to keep flying.
+- **Settings panel (was #39).** New `#settings` panel matching the existing panel
+  pattern; volume sliders + reduce-motion toggle writing to `state.settings`.
+- **Wire any newly-added cross-module functions** through `bridge`/`call()` as
+  other agents surface them.
 
 ---
 
-## Audio & music
+## C. Larger feature backlog (multi-session / cross-cutting)
 
-35. **Background music track(s)**, looping, with a separate music volume/mute control from the existing SFX mute. New lightweight synth loop or a licensed/CC track. **(file: `flightless-sound.js` + HTML controls)** — **M**
-36. **Biome-specific ambience** (wind howl intensity, underwater-muffled tone near open water) layered under the music. **(file: `flightless-sound.js`)** — **M** (depends on #13)
-37. **Richer SFX layering.** Current SFX is minimal procedural blips; add an engine-hum layer that pitches with speed, a distinct wing-flap sound tied to `drawPenguin()`'s flap animation, and impact variety by obstacle type. **(file: `flightless-sound.js`)** — **M**
-38. **Penguin bark lines.** Short procedural or pre-recorded one-liners on milestones/crashes/medal pickups, toggled with SFX. **(file: `flightless-sound.js` + `flightless-results.js`)** — **S**
+These are bigger than a single-file charter and need coordination — schedule
+them *after* the swarm's first pass, one owner at a time.
 
----
+- **Weather system (was #5)** — new `flightless-weather.js`; wind term injected
+  into `stepFlight`. Pairs with the data-side daily modifier table. **L, new file**
+- **Biome progression (was #13)** — segment the 35 km into Ice/Ocean/Cloud/
+  Stratosphere zones with per-zone backdrop (render) and force modifiers
+  (physics) + a "pressure suit" upgrade. **XL, shared**
+- **Weekly boss flight (was #9)** — one-per-week modifier set + large reward,
+  tracked in save. **L, new file**
+- **Mk2 upgrade tier (was #21)** / **branching talents (was #24)** — extend
+  `UPGRADES` with `next` pointers / mutually-exclusive paths. **L, data.js**
+- **Cosmetic unlocks (was #22, #31)** — `COSMETICS` table + shop picker +
+  `drawPenguin`/`drawGlider` reading the equipped skin. **L, shared**
+- **New gear (was #23)** — Parachute / Radar / GPS Compass. **M each, per-module**
+- **New landmark bosses (was #18)** — moving iceberg, penguin-rival wave. **L**
+- **Ghost replay (was #20)** — record `run.trail`, render a translucent ghost. **M**
+- **Night flights (was #17)** — every Nth day, reduced draw distance + glowing
+  collectibles. **M, shared**
+- **Cargo/passenger mode (was #16)** — pre-launch toggle, cash × for tighter
+  g-limits. **M**
+- **Local leaderboard / stat card (was #47)**, **challenge seed codes (was #48)**,
+  **flight history panel (was #43)**, **lore collectibles + journal (was #55)**,
+  **rival banter (was #56)**. Meta/replayability; mostly new panels.
+- **Colorblind-safe palette audit (was #46 CSS half).** **S, HTML CSS**
 
-## UI/UX & accessibility
+## D. Technical / architecture
 
-39. **Settings panel.** Volume sliders (SFX/music separately once #35 lands), reduced-motion toggle (disables camera shake/particle density), control remap for keyboard. New `#settings` panel matching the existing panel pattern in `pages/flightless.html`. **(file: shared — new panel + hud-input.js)** — **M**
-40. **Onboarding pass.** The current intro is a single static screen; consider a short interactive first-flight tutorial that calls out controls contextually (first time pulling up, first stall, first bounce). **(file: `flightless-hud-input.js` + `pages/flightless.html`)** — **M**
-41. **Shop stat projections.** Show a small graph/preview of projected distance or top speed vs. the next 2–3 upgrade levels, not just the immediate next level, so purchases feel more informed. **(file: `flightless-store.js`)** — **M**
-42. **Save export/import.** The save is pure `localStorage` with no backup path — add a "copy save to clipboard" / "paste save" flow in the shop's reset area. **(file: `flightless-save.js` + `flightless-store.js`)** — **S**
-43. **Flight history / stats page.** A new panel showing best runs over time, medals timeline, and simple charts (distance per day) — pure save-data visualization, no new gameplay. **(file: new panel + `flightless-save.js` read)** — **M**
-44. **Pause menu.** There's currently no way to pause mid-flight; add one (space is already thrust, so probably a dedicated key/button) that freezes `sim.phase` stepping without losing state. **(file: `pages/flightless.html` main loop + `flightless-hud-input.js`)** — **S**
-45. **Mobile touch control refinement.** Current touch controls are a bare four-button layout; consider a drag-to-steer gesture as an alternative, plus haptic feedback on supported devices for landings/impacts. **(file: `flightless-hud-input.js`)** — **M**
-46. **Colorblind-safe palette audit + reduced-motion mode.** Check the existing navy/yellow/red palette against common colorblindness types, and ensure `--reduce-motion` respects `prefers-reduced-motion` for camera shake/particles. **(file: `pages/flightless.html` CSS + `flightless-render.js`)** — **S**
-
----
-
-## Meta / replayability / social
-
-47. **Local leaderboard / personal-best gallery.** Snapshot the top N flights (distance/speed/altitude) with a shareable stat card (canvas-rendered image) players can download. **(file: new)** — **M**
-48. **Seasonal/rotating challenge codes.** A shop text field to enter a "seed" that regenerates a specific day's contracts/obstacles deterministically (the hashing is already seeded by day number, so this is mostly UI + a seed override). Lets players compare identical runs. **(file: `flightless-data.js` + `flightless-store.js`)** — **M**
-49. **Achievement expansion.** `MEDALS` in `flightless-data.js` currently covers ~17 medals; there's a lot of headroom for more (biome-specific, weather-specific, style-run medals) once other systems land. **(file: `flightless-data.js`)** — **S, ongoing**
-
----
-
-## Technical / architecture
-
-50. **Unit tests for the pure physics functions.** `derive()`, `buildRamp()`, `rampExitEst()` etc. in `flightless-physics.js` are now isolated pure(-ish) functions — a great, low-risk first target for an actual test suite (no test infra exists yet; this job includes picking one — Vitest is a reasonable default — and wiring a `npm test` script). **(file: new test setup)** — **M**
-51. **Save schema versioning.** `flightless-save.js`'s sanitization is currently ad hoc field-by-field patching; formalize with an explicit `state.version` and a migration function chain so future saves don't need more special-cased patch code appended forever. **(file: `flightless-save.js`)** — **M**
-52. **Build/bundle step.** Currently raw ES modules with no bundler — fine for now, but a `esbuild`/`vite` step (minify + sourcemaps, kept as a build artifact checked into `pages/`) would help once the module count grows further. Coordinate with whoever's touching the most files, since it changes the dev workflow. **(file: new build config)** — **L**
-53. **Performance pass.** Audit `draw()` in `flightless-render.js` for unnecessary per-frame allocations and off-screen draw calls (the cloud/ridge/collectible loops already cull by screen bounds — verify obstacle/landmark draws do too), profile on a mid-tier mobile device. **(file: `flightless-render.js`)** — **M**
-
----
-
-## Narrative & flavor
-
-54. **Expand milestone/headline flavor text.** `finishRun()`'s headline text in `flightless-results.js` currently has 5 tiers; add more variety per tier so repeat flights don't feel as repetitive. **(file: `flightless-results.js`)** — **S**
-55. **Lore collectibles.** Rare, non-cash pickups along the flight path (reuse the golden-fish rarity pattern) that unlock short flavor snippets in a new "journal" panel — worldbuilding without any power effect. **(file: `flightless-world.js` + new panel)** — **M**
-56. **Rival penguin banter.** If a rival/formation mechanic (#14) or race mode ships, give the rival penguin a few contextual lines (falling behind / overtaking you). **(file: `flightless-sound.js` + `flightless-world.js`)** — **S** (depends on a rival mechanic existing)
+- **Unit tests for the pure physics functions (was #50)** — `derive()`,
+  `buildRamp()`, `rampExitEst()`, `sampleShape()` are pure and test-friendly.
+  Pick Vitest, wire `npm test`. **M, new**
+- **Build/bundle step (was #52)** — esbuild/vite for minify+sourcemaps once the
+  module count grows. **L, new; coordinate**
+- **Performance pass (was #53)** — `draw()` allocation audit. Note: the
+  cloud/ridge/collectible/obstacle loops *already* cull by screen bounds;
+  landmark draw culls by x. Verify particle/trail loops and profile on mid-tier
+  mobile. **M**
 
 ---
 
-## Suggested first wave (if you want a starting slice)
+## Suggested swarm (per-component, parallel-safe)
 
-A good initial swarm split, minimizing file collisions:
-- Agent A: **P0 #1–4** (wall fix + feedback) — small, sequential, high impact, do this first regardless of what else runs in parallel.
-- Agent B: **#5 Weather system** (new file)
-- Agent C: **#27–30 render/VFX polish** (same file, one agent to avoid conflicts)
-- Agent D: **#35–38 audio pass** (same file, one agent)
-- Agent E: **#39, #43, #44 UI/UX additions** (new panels, low collision with gameplay work)
-- Agent F: **#50 test infra** (fully new, zero collision risk, unblocks safer iteration on everything else)
+Run **one agent per file**, all at once — the charters in §B are scoped so no
+two agents touch the same file. Priority order if capacity is limited:
+
+1. **`world.js`** — owns P0 #1 & #3 (the biggest fun-blocker). Start first.
+2. **`data.js`** — P0 #2 & #4 + rebalance (pairs with world's numbers).
+3. **`save.js`** — versioning + forward-looking default fields *unblocks*
+   store/results/sound/render/html consuming new `state.*` fields.
+4. **`physics.js`, `render.js`, `sound.js`, `store.js`, `hud-input.js`,
+   `results.js`, `flightless.html`** — independent §B slates, any order.
+
+The only cross-file touchpoints are the **reserved shared properties** in the
+invariants (`sim.paused`, `state.musicMuted/settings/ngPlus`); everyone reads
+them defensively, so ordering doesn't matter for correctness.

--- a/assets/js/flightless-data.js
+++ b/assets/js/flightless-data.js
@@ -3,14 +3,24 @@
 // Every tunable table the game reads from: upgrade/gear/bonus-shop
 // catalogs, medals, distance milestones, obstacle types, and the daily
 // contract pool. No behavior lives here beyond the small pure helpers
-// (upgCost, contractsFor) that just look values up in these tables —
-// the actual physics/sim/UI code that acts on them lives elsewhere.
+// (upgCost, contractsFor, dailyModFor, dailyDealFor) that just look
+// values up in these tables — the actual physics/sim/UI code that acts
+// on them lives elsewhere.
 //
 // A few upgrade cards preview live stats (ramp length/height, glide ratio,
 // dive speed) by calling into the physics module, so those are injected
 // rather than imported directly — this module has no dependency of its
 // own on how flight is simulated.
 export function createData({ state, derive, buildRamp, rampExitEst, gliderName, clamp, hash01 }){
+
+  // ─── UPGRADES ────────────────────────────────────────────────────────────
+  // Cost formula: Math.round(base * mul^level). Levels are 0-indexed, so
+  // level 0 costs `base` and you buy your way up. Tuning goals:
+  //   • Early gear (ramp/wings/aero/bounce) should be affordable in 1-3 days.
+  //   • Mid-tier (struts/rocket/fuel/sling) takes a week of moderate flights.
+  //   • Late-tier (sponsor/plating/gun) takes sustained good flights to max.
+  // mul raised from 1.55 on rocket/gun to slow their late-level cost climb.
+
   const UPGRADES = [
     { id:'ramp',    icon:'\u{1F6DD}', name:'Ramp Track',   base:15,  mul:1.55, max:12, unlock:0,
       desc:'More track to build speed on. Reshape it in the designer below.',
@@ -29,13 +39,18 @@ export function createData({ state, derive, buildRamp, rampExitEst, gliderName, 
     { id:'struts',  icon:'\u{1F529}', name:'Wing Struts',  base:180, mul:1.55, max:6, unlock:250, requires:'wings',
       desc:'Stiffer spars pull harder turns at speed without folding.',
       val:l=>`${derive({struts:l}).gMax.toFixed(1)}g max pull` },
-    { id:'rocket',  icon:'\u{1F680}', name:'Rocket',       base:100, mul:1.55, max:10, unlock:100,
+    // Rocket: base raised 100→180, mul raised 1.55→1.65 to slow the runaway
+    // late-game power spike. At max (10) the total tree cost is ~$60k rather
+    // than ~$13k, spreading pressure across more flights.
+    { id:'rocket',  icon:'\u{1F680}', name:'Rocket',       base:180, mul:1.65, max:10, unlock:100,
       desc:'A strap-on booster. Hold SPACE to climb faster.',
-      val:l=> l===0 ? 'not installed' : `${10+8*l} m/s² thrust` },
-    { id:'fuel',    icon:'⛽',    name:'Fuel Tank',    base:60,  mul:1.55, max:10, unlock:100,
+      val:l=> l===0 ? 'not installed' : `${Math.round(derive({rocket:l}).thrust)} m/s² thrust` },
+    { id:'fuel',    icon:'⛽',    name:'Fuel Tank',    base:80,  mul:1.55, max:10, unlock:100,
       desc:'More burn time for sustained climbs.', requires:'rocket',
       val:l=>`${(2+1.3*l).toFixed(1)} s of burn` },
-    { id:'sponsor', icon:'\u{1F4B0}', name:'Sponsor Deal', base:250, mul:1.55, max:6, unlock:250,
+    // Sponsor: base raised 250→400 so it doesn't trivialize the cash curve
+    // until mid-game. Its multiplier stacks hard with airtime — keep it late.
+    { id:'sponsor', icon:'\u{1F4B0}', name:'Sponsor Deal', base:400, mul:1.60, max:6, unlock:250,
       desc:'Fish Co. multiplies your earnings on every flight.',
       val:l=>`×${(1+0.35*l).toFixed(2)} cash earned` },
     { id:'sling',   icon:'\u{1F3AF}', name:'Catapult',     base:400, mul:1.55, max:8, unlock:500,
@@ -45,12 +60,15 @@ export function createData({ state, derive, buildRamp, rampExitEst, gliderName, 
       desc:'An armored belly plate. Smash landmarks harder and keep more speed on impact.',
       val:l=>`×${(1+0.35*l).toFixed(2)} smash damage`,
     },
-    { id:'gun',     icon:'\u{1F52B}', name:'Sky Cannon',   base:3000, mul:1.7,  max:6, unlock:2500,
+    // Gun: base raised 3000→4500, mul raised 1.7→1.75 — a true late-game luxury.
+    { id:'gun',     icon:'\u{1F52B}', name:'Sky Cannon',   base:4500, mul:1.75, max:6, unlock:2500,
       desc:'Press C to blast obstacles out of the sky. Upgrade for range and bigger targets.',
       val:l=>{ if(l===0) return 'not installed';
                const tier = l>=5?'planes':l>=3?'balloons':'birds';
                return `range ${260+90*l}m · downs ${tier}`; } },
   ];
+
+  // ─── GEAR ─────────────────────────────────────────────────────────────────
   const GEAR = [
     { id:'speedo', icon:'\u{1F4DF}', name:'Speedometer', cost:60,   unlock:0,
       desc:'See your speed — and get paid for top speed.' },
@@ -61,32 +79,101 @@ export function createData({ state, derive, buildRamp, rampExitEst, gliderName, 
     { id:'tank',   icon:'\u{1F6E2}', name:'Reserve Tank', cost:6000, unlock:2500,
       desc:'Rocket refuels to half on your first ground bounce.' },
   ];
+
   const upgCost = u => Math.round(u.base * Math.pow(u.mul, state.lvl[u.id]));
 
+  // ─── MILESTONES ───────────────────────────────────────────────────────────
+  // Each entry is [dist_m, cash_reward]. Claimed once ever (state.claimed).
+  //
+  // OLD: 9 milestones, final [35000, $100 000]. A single max-rocket 35 km
+  // flight paid ~$343 k total (subtotal + milestones), trivializing the whole
+  // upgrade tree in one run.
+  //
+  // NEW: 14 milestones. The final stretch (15 km→35 km) is sliced into 5
+  // additional steps, and the cap per milestone is held to $15 000. A full
+  // clean sweep of all milestones yields $82 200 (vs. ~$163 000 before), but
+  // they are drip-fed across many flights instead of front-loaded at 35 km.
+  //
+  // Paper economy check:
+  //   Day-1 flop 50 m   → dist cash ~$84, milestone 100→$150 if hit. Total ≈ $220.
+  //   Mid-game 5 000 m  → subtotal ~$13 k, milestones ≤$13 k (5 steps). Total ≈ $26 k.
+  //   35 km win         → subtotal ~$82 k (payMult 6.2), milestones ≤$35 k (partial).
+  //                        Total flight ≈ $115 k — still more than the upgrade tree
+  //                        (~$105 k cumulative), but it takes multiple 35 km flights
+  //                        because you won't collect all 14 milestones in one go.
   const MILESTONES = [
-    [100,150],[250,300],[500,600],[1000,1200],[2500,3000],
-    [5000,7000],[10000,15000],[20000,35000],[35000,100000],
+    [100,    150],
+    [250,    300],
+    [500,    600],
+    [1000,   1200],
+    [2500,   3000],
+    [5000,   6000],   // was 7 000 — trimmed so 5 km run doesn't over-pay
+    [8000,   8000],   // new: 8 km rung
+    [12000,  10000],  // new: 12 km rung
+    [15000,  10000],  // new: 15 km rung
+    [18000,  10000],  // new: 18 km rung
+    [22000,  10000],  // new: 22 km rung
+    [25000,  10000],  // was folded into 35 km lump — now its own step
+    [30000,  10000],  // new: 30 km rung
+    [35000,  15000],  // was 100 000 — cut to 15 000; glory is defeating the Wall
   ];
+
+  // ─── WIN_DIST ─────────────────────────────────────────────────────────────
+  // Canonical source-of-truth for the Wall's distance (matches LANDMARKS.wall.x).
+  // Exported because flightless.html's ngPlusWallDist() multiplies it for NG+:
+  //   ngPlusWallDist = WIN_DIST * 2 * (ngPlus + 1)
+  // The in-game win condition is state.lmHP.wall <= 0 (not reaching this
+  // distance), but WIN_DIST is still the correct number to build NG+ math on.
   const WIN_DIST = 35000;
 
-  // Birds, balloons and planes share one x-cell grid; each cell deterministically
-  // rolls a type then an existence chance, same trick as the coin/star fields.
+  // ─── OBSTACLE_TYPES ───────────────────────────────────────────────────────
   const OBSTACLE_TYPES = [
     { id:'bird',    tough:1, cash:40,  minAlt:25,   maxAlt:1400, r:16, skip:0.3 },
     { id:'balloon', tough:3, cash:150, minAlt:600,  maxAlt:3200, r:28, skip:0.45 },
     { id:'plane',   tough:5, cash:500, minAlt:1800, maxAlt:6000, r:36, skip:0.55 },
   ];
 
+  // ─── CONTRACT_POOL ────────────────────────────────────────────────────────
   // Two per-day side objectives, deterministic from the day number and scaled
   // to current progress. Checked at the end of the flight; paid in results.
+  // Style-based entries added: combo, stars, gunKills, skimT combos.
   const CONTRACT_POOL = [
-    { id:'fish',  txt:n=>`Catch ${n} fish`,            tgt:b=>clamp(Math.round(3 + b.dist/400), 3, 20),  val:r=>r.coinCount },
-    { id:'rings', txt:n=>`Fly through ${n} ring${n>1?'s':''}`, tgt:b=>clamp(Math.round(1 + b.dist/1500), 1, 6), val:r=>r.ringCount },
-    { id:'skim',  txt:n=>`Skim the ice for ${n}s`,     tgt:b=>clamp(Math.round(2 + b.dist/2500), 2, 8),  val:r=>Math.floor(r.skimT) },
-    { id:'spd',   txt:n=>`Hit ${n} m/s`,               tgt:b=>Math.round(clamp(b.spd*1.1 + 5, 30, 400)), val:r=>Math.round(r.maxSpd) },
-    { id:'alt',   txt:n=>`Reach ${n} m altitude`,      tgt:b=>Math.round(clamp(b.alt*1.15 + 10, 30, 8000)), val:r=>Math.round(r.maxAlt) },
-    { id:'bounce',txt:n=>`Bounce ${n} times`,          tgt:b=>clamp(2 + Math.floor(b.dist/3000), 2, 6),  val:r=>r.bounceCount },
+    { id:'fish',   txt:n=>`Catch ${n} fish`,
+      tgt:b=>clamp(Math.round(3 + b.dist/400), 3, 20),
+      val:r=>r.coinCount },
+    { id:'rings',  txt:n=>`Fly through ${n} ring${n>1?'s':''}`,
+      tgt:b=>clamp(Math.round(1 + b.dist/1500), 1, 6),
+      val:r=>r.ringCount },
+    { id:'skim',   txt:n=>`Skim the ice for ${n}s`,
+      tgt:b=>clamp(Math.round(2 + b.dist/2500), 2, 8),
+      val:r=>Math.floor(r.skimT) },
+    { id:'spd',    txt:n=>`Hit ${n} m/s`,
+      tgt:b=>Math.round(clamp(b.spd*1.1 + 5, 30, 400)),
+      val:r=>Math.round(r.maxSpd) },
+    { id:'alt',    txt:n=>`Reach ${n} m altitude`,
+      tgt:b=>Math.round(clamp(b.alt*1.15 + 10, 30, 8000)),
+      val:r=>Math.round(r.maxAlt) },
+    { id:'bounce', txt:n=>`Bounce ${n} times`,
+      tgt:b=>clamp(2 + Math.floor(b.dist/3000), 2, 6),
+      val:r=>r.bounceCount },
+    // Style contracts — uses existing run fields only
+    { id:'combo',  txt:n=>`Build a ×${n} combo`,
+      tgt:b=>clamp(2 + Math.floor(b.dist/4000), 2, 8),
+      val:r=>r.maxCombo },
+    { id:'stars',  txt:n=>`Collect ${n} star${n>1?'s':''}`,
+      tgt:b=>clamp(Math.round(1 + b.dist/3000), 1, 8),
+      val:r=>r.starCount },
+    { id:'gun',    txt:n=>`Down ${n} target${n>1?'s':''} with the cannon`,
+      tgt:b=>clamp(1 + Math.floor(b.dist/5000), 1, 6),
+      val:r=>r.gunKills },
+    { id:'smash',  txt:n=>`Smash through ${n} obstacle${n>1?'s':''}`,
+      tgt:b=>clamp(2 + Math.floor(b.dist/4000), 2, 6),
+      val:r=>r.obHits },
+    { id:'lowfly', txt:n=>`Skim for ${n}s AND catch 3 fish`,
+      tgt:b=>clamp(Math.round(3 + b.dist/3000), 3, 10),
+      val:r=>Math.min(Math.floor(r.skimT), r.coinCount >= 3 ? 999 : 0) },
   ];
+
   function contractsFor(day){
     const b = state.best;
     const a = Math.floor(hash01(day*13+3)*CONTRACT_POOL.length);
@@ -99,36 +186,87 @@ export function createData({ state, derive, buildRamp, rampExitEst, gliderName, 
     });
   }
 
+  // ─── LANDMARKS ────────────────────────────────────────────────────────────
   // Physical bosses standing on the ice. Fly into one to damage it — the hurt
   // persists between days — and bring it down for a payout. The Wall is the
   // real victory condition. You CAN fly over them, but they won't forget you.
+  //
+  // HP retuned so a skilled maxed build can down the Wall in 1–2 flights
+  // (world.js rework converts knockback to a slowdown, allowing sustained
+  // damage per pass). Damage per pass at max plating+skull ≈ 1000–1500 hp,
+  // so 8 000 hp means 5–8 hits total across 1–2 good flights.
+  // Rewards trimmed to fit the new milestone economy (no more $30 k lump).
+  //
+  //   OLD: snowman hp:400/$2000 · iceberg hp:2500/$8000 · wall hp:12000/$30000
+  //   NEW: snowman hp:350/$1500 · iceberg hp:2000/$6000 · wall hp:8000/$20000
   const LANDMARKS = [
-    { id:'snowman', x:2500,  w:34, h:75,   hp:400,   reward:2000,  name:'Giant Snowman', color:'#ffffff' },
-    { id:'iceberg', x:10000, w:70, h:300,  hp:2500,  reward:8000,  name:'The Iceberg',   color:'#bfe6ff' },
-    { id:'wall',    x:35000, w:46, h:1300, hp:12000, reward:30000, name:'THE WALL',      color:'#c9b8a0' },
+    { id:'snowman', x:2500,  w:34, h:75,   hp:350,  reward:1500,  name:'Giant Snowman', color:'#ffffff' },
+    { id:'iceberg', x:10000, w:70, h:300,  hp:2000, reward:6000,  name:'The Iceberg',   color:'#bfe6ff' },
+    { id:'wall',    x:35000, w:46, h:1300, hp:8000, reward:20000, name:'THE WALL',      color:'#c9b8a0' },
   ];
 
-  // Medals are permanent achievements worth Bonus Points; BP buys permanent
-  // bonus-shop levels. All three survive a progress reset — the prestige loop.
+  // ─── MEDALS ───────────────────────────────────────────────────────────────
+  // Permanent achievements worth Bonus Points; BP buys bonus-shop levels.
+  // All three survive a progress reset — the prestige loop.
+  // New medals added for style play (combo chains, stars, endurance, accuracy).
   const MEDALS = [
-    { id:'first',   bp:1, icon:'\u{1F423}', name:'Leap of Faith',      desc:'Complete your first flight',        chk:r=>true },
-    { id:'century', bp:1, icon:'\u{1F4CF}', name:'Century',            desc:'Fly 100 m',                         chk:r=>r.dist>=100 },
-    { id:'kmclub',  bp:1, icon:'\u{1F6E3}', name:'Kilometre Club',     desc:'Fly 1 km',                          chk:r=>r.dist>=1000 },
-    { id:'fivek',   bp:2, icon:'\u{1F680}', name:'Frequent Flyer',     desc:'Fly 5 km',                          chk:r=>r.dist>=5000 },
-    { id:'stratos', bp:2, icon:'\u{1F30C}', name:'Stratospheric',      desc:'Reach 3,000 m altitude',            chk:r=>r.maxAlt>=3000 },
-    { id:'mach',    bp:2, icon:'\u{1F4A8}', name:'Mach Penguin',       desc:'Hit 200 m/s',                       chk:r=>r.maxSpd>=200 },
-    { id:'fish10',  bp:1, icon:'\u{1F41F}', name:'Fish Magnet',        desc:'Catch 10 fish in one flight',       chk:r=>r.coinCount>=10 },
-    { id:'combo5',  bp:2, icon:'\u{1F517}', name:'Chain Reaction',     desc:'Reach a ×5 combo',             chk:r=>r.maxCombo>=5 },
-    { id:'ring5',   bp:2, icon:'\u{2B55}',  name:'Ring Master',        desc:'Thread 5 rings in one flight',      chk:r=>r.ringCount>=5 },
-    { id:'skim10',  bp:2, icon:'\u{2744}',  name:'Belly Surfer',       desc:'Skim the ice for 10 s in one flight', chk:r=>r.skimT>=10 },
-    { id:'bounce6', bp:1, icon:'\u{1F3C0}', name:'Superball',          desc:'Bounce 6 times in one flight',      chk:r=>r.bounceCount>=6 },
-    { id:'ace',     bp:2, icon:'\u{1F3AF}', name:'Sky Ace',            desc:'Down 5 targets in one flight',      chk:r=>r.gunKills>=5 },
-    { id:'ouch',    bp:1, icon:'\u{1F915}', name:'Crash Test Penguin', desc:'Hit 3 obstacles in one flight',     chk:r=>r.obHits>=3 },
-    { id:'kit',     bp:2, icon:'\u{1F9F0}', name:'Fully Loaded',       desc:'Own every piece of permanent gear', chk:()=>Object.values(state.perm).every(v=>v) },
-    { id:'snowman', bp:2, icon:'\u{26C4}',  name:"Frosty's Bane",      desc:'Demolish the Giant Snowman',        chk:()=>state.lmHP.snowman<=0 },
-    { id:'iceberg', bp:3, icon:'\u{1F9CA}', name:'Cold Revenge',       desc:'Shatter the Iceberg',               chk:()=>state.lmHP.iceberg<=0 },
-    { id:'wall',    bp:5, icon:'\u{1F9F1}', name:'Another Brick',      desc:'Bring down The Wall',               chk:()=>state.lmHP.wall<=0 },
+    { id:'first',    bp:1, icon:'\u{1F423}', name:'Leap of Faith',
+      desc:'Complete your first flight',               chk:r=>true },
+    { id:'century',  bp:1, icon:'\u{1F4CF}', name:'Century',
+      desc:'Fly 100 m',                                chk:r=>r.dist>=100 },
+    { id:'kmclub',   bp:1, icon:'\u{1F6E3}', name:'Kilometre Club',
+      desc:'Fly 1 km',                                 chk:r=>r.dist>=1000 },
+    { id:'fivek',    bp:2, icon:'\u{1F680}', name:'Frequent Flyer',
+      desc:'Fly 5 km',                                 chk:r=>r.dist>=5000 },
+    { id:'tenk',     bp:2, icon:'\u{1F30D}', name:'Ten-K',
+      desc:'Fly 10 km',                                chk:r=>r.dist>=10000 },
+    { id:'twentyk',  bp:3, icon:'\u{1F30C}', name:'Horizon Chaser',
+      desc:'Fly 20 km',                                chk:r=>r.dist>=20000 },
+    { id:'stratos',  bp:2, icon:'\u{1F30C}', name:'Stratospheric',
+      desc:'Reach 3,000 m altitude',                   chk:r=>r.maxAlt>=3000 },
+    { id:'ionosphere',bp:3,icon:'\u{2728}',  name:'Ionospheric',
+      desc:'Reach 6,000 m altitude',                   chk:r=>r.maxAlt>=6000 },
+    { id:'mach',     bp:2, icon:'\u{1F4A8}', name:'Mach Penguin',
+      desc:'Hit 200 m/s',                              chk:r=>r.maxSpd>=200 },
+    { id:'hypersonic',bp:3,icon:'\u{1F525}', name:'Hypersonic',
+      desc:'Hit 350 m/s',                              chk:r=>r.maxSpd>=350 },
+    { id:'fish10',   bp:1, icon:'\u{1F41F}', name:'Fish Magnet',
+      desc:'Catch 10 fish in one flight',              chk:r=>r.coinCount>=10 },
+    { id:'fish20',   bp:2, icon:'\u{1F420}', name:'Shoal Surfer',
+      desc:'Catch 20 fish in one flight',              chk:r=>r.coinCount>=20 },
+    { id:'combo5',   bp:2, icon:'\u{1F517}', name:'Chain Reaction',
+      desc:'Reach a ×5 combo',                         chk:r=>r.maxCombo>=5 },
+    { id:'combo10',  bp:3, icon:'\u{26D3}',  name:'Unbreakable',
+      desc:'Reach a ×10 combo',                        chk:r=>r.maxCombo>=10 },
+    { id:'ring5',    bp:2, icon:'\u{2B55}',  name:'Ring Master',
+      desc:'Thread 5 rings in one flight',             chk:r=>r.ringCount>=5 },
+    { id:'ring8',    bp:3, icon:'\u{1F4CD}', name:'Ring Lord',
+      desc:'Thread 8 rings in one flight',             chk:r=>r.ringCount>=8 },
+    { id:'skim10',   bp:2, icon:'\u{2744}',  name:'Belly Surfer',
+      desc:'Skim the ice for 10 s in one flight',      chk:r=>r.skimT>=10 },
+    { id:'skim20',   bp:3, icon:'\u{1F9CA}', name:'Ice Dancer',
+      desc:'Skim the ice for 20 s in one flight',      chk:r=>r.skimT>=20 },
+    { id:'bounce6',  bp:1, icon:'\u{1F3C0}', name:'Superball',
+      desc:'Bounce 6 times in one flight',             chk:r=>r.bounceCount>=6 },
+    { id:'ace',      bp:2, icon:'\u{1F3AF}', name:'Sky Ace',
+      desc:'Down 5 targets in one flight',             chk:r=>r.gunKills>=5 },
+    { id:'topgun',   bp:3, icon:'\u{1F52B}', name:'Top Gun',
+      desc:'Down 10 targets in one flight',            chk:r=>r.gunKills>=10 },
+    { id:'ouch',     bp:1, icon:'\u{1F915}', name:'Crash Test Penguin',
+      desc:'Hit 3 obstacles in one flight',            chk:r=>r.obHits>=3 },
+    { id:'stars5',   bp:2, icon:'\u{2B50}',  name:'Star Collector',
+      desc:'Collect 5 stars in one flight',            chk:r=>r.starCount>=5 },
+    { id:'kit',      bp:2, icon:'\u{1F9F0}', name:'Fully Loaded',
+      desc:'Own every piece of permanent gear',        chk:()=>Object.values(state.perm).every(v=>v) },
+    { id:'snowman',  bp:2, icon:'\u{26C4}',  name:"Frosty's Bane",
+      desc:'Demolish the Giant Snowman',               chk:()=>state.lmHP.snowman<=0 },
+    { id:'iceberg',  bp:3, icon:'\u{1F9CA}', name:'Cold Revenge',
+      desc:'Shatter the Iceberg',                      chk:()=>state.lmHP.iceberg<=0 },
+    { id:'wall',     bp:5, icon:'\u{1F9F1}', name:'Another Brick',
+      desc:'Bring down The Wall',                      chk:()=>state.lmHP.wall<=0 },
   ];
+
+  // ─── BONUS_SHOP ───────────────────────────────────────────────────────────
   const BONUS_SHOP = [
     { id:'aero',  icon:'\u{1FAB6}', name:'Penguin Physique', max:3, cost:[2,4,6],
       desc:'Molted down to racing feathers: −7% drag per level. Permanent — survives resets.' },
@@ -138,8 +276,80 @@ export function createData({ state, derive, buildRamp, rampExitEst, gliderName, 
       desc:'Pure bone. +40% smash damage per level. Permanent.' },
   ];
 
+  // ─── DAILY MODIFIER TABLE ─────────────────────────────────────────────────
+  // Each entry is a descriptor that physics/world can read defensively from
+  // state.dailyMod (seeded by calling dailyModFor(state.day) at launch).
+  // The `id` is unique; `label` is display text; numeric fields are multipliers
+  // or additive offsets the physics module applies to its force sum when present.
+  //
+  // Only safe-to-ignore fields — consumers check for their own known ids and
+  // fall back to neutral values. Adding new entries here is backward-safe.
+  const DAILY_MOD_TABLE = [
+    { id:'calm',      label:'Calm Day',       windX:0,    windY:0,    dragMul:1.00, cashMul:1.00 },
+    { id:'tailwind',  label:'Tailwind',       windX:4,    windY:0,    dragMul:0.92, cashMul:1.00 },
+    { id:'headwind',  label:'Headwind',       windX:-5,   windY:0,    dragMul:1.10, cashMul:1.20 },
+    { id:'updraft',   label:'Updraft',        windX:0,    windY:3,    dragMul:0.95, cashMul:1.00 },
+    { id:'downdraft', label:'Downdraft',      windX:0,    windY:-4,   dragMul:1.05, cashMul:1.15 },
+    { id:'slippery',  label:'Icy Runway',     windX:0,    windY:0,    dragMul:0.85, cashMul:1.00 },
+    { id:'dense',     label:'Dense Air',      windX:0,    windY:0,    dragMul:1.20, cashMul:1.25 },
+    { id:'bonusday',  label:'Sponsor\'s Day', windX:0,    windY:0,    dragMul:1.00, cashMul:1.50 },
+    { id:'gusty',     label:'Gusty Winds',    windX:3,    windY:2,    dragMul:1.08, cashMul:1.10 },
+  ];
+
+  // ─── DAILY DEAL TABLE ─────────────────────────────────────────────────────
+  // Each entry names an upgrade id and a discount fraction (0.3 = 30% off).
+  // dailyDealFor(day) picks one deterministically; store.js renders it with a
+  // badge if it detects the export. Consumers apply cost * (1 - deal.discount).
+  const DAILY_DEAL_TABLE = [
+    { upgradeId:'ramp',    discount:0.30 },
+    { upgradeId:'wings',   discount:0.25 },
+    { upgradeId:'aero',    discount:0.25 },
+    { upgradeId:'bounce',  discount:0.20 },
+    { upgradeId:'struts',  discount:0.20 },
+    { upgradeId:'rocket',  discount:0.35 },
+    { upgradeId:'fuel',    discount:0.25 },
+    { upgradeId:'sponsor', discount:0.20 },
+    { upgradeId:'sling',   discount:0.20 },
+    { upgradeId:'plating', discount:0.20 },
+    { upgradeId:'gun',     discount:0.30 },
+  ];
+
+  // ─── DAILY HELPERS ────────────────────────────────────────────────────────
+  // Both functions reuse the hash01-based pattern from contractsFor() so the
+  // results are deterministic for a given day and never call Math.random().
+
+  /**
+   * dailyModFor(day) → one entry from DAILY_MOD_TABLE.
+   * Physics/world read it as state.dailyMod (set defensively at launch):
+   *   const mod = dailyModFor(state.day);
+   *   // in stepFlight: vx += mod.windX * dt;  vy += mod.windY * dt; etc.
+   */
+  function dailyModFor(day){
+    const idx = Math.floor(hash01(day * 17 + 7) * DAILY_MOD_TABLE.length);
+    return DAILY_MOD_TABLE[idx];
+  }
+
+  /**
+   * dailyDealFor(day) → one entry from DAILY_DEAL_TABLE, or null on calm days.
+   * Store reads it defensively:
+   *   const deal = typeof dailyDealFor==='function' ? dailyDealFor(state.day) : null;
+   *   if(deal) applyCostBadge(deal.upgradeId, deal.discount);
+   * There is no deal on ~2 in 9 days (calm/bonusday) to keep it meaningful.
+   */
+  function dailyDealFor(day){
+    const mod = dailyModFor(day);
+    // No deal on calm or bonus-cash days — they already have other advantages.
+    if(mod.id === 'calm' || mod.id === 'bonusday') return null;
+    const idx = Math.floor(hash01(day * 23 + 5) * DAILY_DEAL_TABLE.length);
+    return DAILY_DEAL_TABLE[idx];
+  }
+
+  // ─── EXPORTS ──────────────────────────────────────────────────────────────
   return {
     UPGRADES, GEAR, upgCost, MILESTONES, WIN_DIST, OBSTACLE_TYPES,
     CONTRACT_POOL, contractsFor, LANDMARKS, MEDALS, BONUS_SHOP,
+    // New exports — consumed defensively (typeof guard) by other modules:
+    DAILY_MOD_TABLE, dailyModFor,
+    DAILY_DEAL_TABLE, dailyDealFor,
   };
 }

--- a/assets/js/flightless-hud-input.js
+++ b/assets/js/flightless-hud-input.js
@@ -12,9 +12,39 @@ export function createHudInput(deps){
     startLaunch, closeResults, skipSlide, fireAfterburner, fireGun,
   } = deps;
 
-  /* ════════════════ input ════════════════ */
-  // `input` is created once in the host page and shared with the physics
-  // and renderer modules, which read it every frame — not owned here.
+  /* ════════════════ sim.paused contract ════════════════ */
+  // Set here; the HTML main loop reads it to freeze sim stepping.
+  // Only meaningful during 'ramp'/'flight' phases.
+  sim.paused = false;
+
+  /* ════════════════ device detection ════════════════ */
+  const isCoarse = window.matchMedia('(pointer:coarse)').matches;
+
+  /* ════════════════ contextual onboarding flags ════════════════ */
+  // Each fires at most once per session.
+  let shownPullUp   = false;
+  let shownStall    = false;
+  let shownBounce   = false;
+
+  // Last-seen values for haptic polling and bounce detection.
+  let _lastBounceCount = 0;
+  let _lastSliding     = false;
+
+  /* ════════════════ pause helper ════════════════ */
+  const hintEl = document.getElementById('hint');
+
+  function togglePause(){
+    const phase = sim.phase;
+    if(phase !== 'ramp' && phase !== 'flight') return;
+    sim.paused = !sim.paused;
+    if(sim.paused){
+      hintEl.textContent = 'PAUSED — press P or Escape to resume';
+      hintEl.style.display = 'block';
+    }
+    // When unpausing let the next renderHUD call restore the normal hint.
+  }
+
+  /* ════════════════ touch controls ════════════════ */
   function bindHold(el, prop){
     const on = e => { e.preventDefault(); input[prop]=true; SFX.ensure(); };
     const off = () => { input[prop]=false; };
@@ -30,8 +60,52 @@ export function createHudInput(deps){
   document.getElementById('t-burner').addEventListener('pointerdown', e => { e.preventDefault(); fireAfterburner(); });
   document.getElementById('t-gun').addEventListener('pointerdown', e => { e.preventDefault(); fireGun(); });
 
+  /* ── Pause button injected into touch controls ── */
+  // We reuse the existing #touch panel by appending a pause button to the
+  // right group so it sits alongside the existing action buttons.
+  const pauseBtn = document.createElement('button');
+  pauseBtn.id = 't-pause';
+  pauseBtn.className = 'tbtn';
+  pauseBtn.setAttribute('aria-label', 'pause');
+  pauseBtn.innerHTML = '&#9646;&#9646;'; // ❚❚
+  pauseBtn.style.fontSize = '18px';
+  const rightGroup = document.querySelector('#touch .tgroup:last-child');
+  if(rightGroup) rightGroup.appendChild(pauseBtn);
+  pauseBtn.addEventListener('pointerdown', e => { e.preventDefault(); SFX.ensure(); togglePause(); });
+
+  /* ── Drag-to-steer on the canvas ── */
+  // A vertical swipe/drag on the canvas sets up/down; doesn't interfere with
+  // the existing #t-up / #t-down buttons.
+  const canvas = document.getElementById('game');
+  let dragStartY = null;
+  const DRAG_DEAD = 12; // px deadzone before registering direction
+
+  canvas.addEventListener('pointerdown', e => {
+    // Only activate during flight; ignore multi-touch fingers beyond first.
+    if(sim.phase !== 'flight' && sim.phase !== 'ramp') return;
+    if(e.isPrimary === false) return;
+    dragStartY = e.clientY;
+  });
+  canvas.addEventListener('pointermove', e => {
+    if(dragStartY === null || !e.isPrimary) return;
+    const dy = e.clientY - dragStartY;
+    if(Math.abs(dy) < DRAG_DEAD){ input.up = false; input.down = false; return; }
+    input.up   = dy < 0;   // swipe up   → pull up
+    input.down = dy > 0;   // swipe down → dive
+  });
+  function endDrag(){
+    if(dragStartY === null) return;
+    dragStartY = null;
+    input.up   = false;
+    input.down = false;
+  }
+  canvas.addEventListener('pointerup',     endDrag);
+  canvas.addEventListener('pointercancel', endDrag);
+  canvas.addEventListener('pointerleave',  endDrag);
+
+  /* ════════════════ keyboard ════════════════ */
   const introEl = document.getElementById('intro');
-  const shopEl = document.getElementById('shop');
+  const shopEl  = document.getElementById('shop');
 
   window.addEventListener('keydown', e => {
     if(e.repeat) return;
@@ -42,7 +116,9 @@ export function createHudInput(deps){
       case 'KeyF': input.ff=true; break;
       case 'KeyX': fireAfterburner(); break;
       case 'KeyC': fireGun(); break;
+      case 'KeyP': case 'Escape': togglePause(); e.preventDefault(); break;
       case 'Enter':
+        if(sim.paused) break; // eat Enter while paused, don't advance menus
         if(introEl.classList.contains('show')) startLaunch();
         else if(sim.phase==='shop' && shopEl.classList.contains('show')) startLaunch();
         else if(sim.phase==='results') closeResults();
@@ -60,20 +136,51 @@ export function createHudInput(deps){
   });
 
   /* ════════════════ HUD ════════════════ */
-  const hintEl = document.getElementById('hint');
-  const ffBtn = document.getElementById('ff-btn');
-  const hudDist = document.getElementById('hud-dist');
-  const hudAlt = document.getElementById('hud-alt');
-  const hudSpd = document.getElementById('hud-spd');
-  const altWrap = document.getElementById('alt-wrap');
-  const spdWrap = document.getElementById('spd-wrap');
-  const fuelWrap = document.getElementById('fuel-wrap');
-  const fuelBar = document.getElementById('fuel-bar');
-  const burnerWrap = document.getElementById('burner-wrap');
+  const ffBtn     = document.getElementById('ff-btn');
+  const hudDist   = document.getElementById('hud-dist');
+  const hudAlt    = document.getElementById('hud-alt');
+  const hudSpd    = document.getElementById('hud-spd');
+  const altWrap   = document.getElementById('alt-wrap');
+  const spdWrap   = document.getElementById('spd-wrap');
+  const fuelWrap  = document.getElementById('fuel-wrap');
+  const fuelBar   = document.getElementById('fuel-bar');
+  const burnerWrap= document.getElementById('burner-wrap');
   const hudBurner = document.getElementById('hud-burner');
+
+  // Hint text branches: keyboard phrasing vs touch phrasing.
+  function flightHintText(st){
+    if(!st) return '';
+    if(isCoarse){
+      // Touch device: reference the on-screen buttons.
+      return (state.lvl?.wings > 0)
+        ? '⬆ pull up · ⬇ dive for speed'
+          + (st.thrust > 0 ? ' · \u{1F525} rocket' : '')
+          + (st.gunLevel > 0 ? ' · \u{1F52B} fire' : '')
+        : 'no wings yet… enjoy the flop';
+    } else {
+      // Keyboard/mouse device: reference key bindings.
+      return (state.lvl?.wings > 0)
+        ? '⇧ pull up · ⇩ dive for speed'
+          + (st.thrust > 0 ? ' · SPACE rocket' : '')
+          + (st.gunLevel > 0 ? ' · C fire cannon' : '')
+          + ' · F fast-forward · P pause'
+        : 'no wings yet… enjoy the flop';
+    }
+  }
+
+  // One-time contextual hint overlay: shows briefly over the normal hint area.
+  let contextHintTimer = 0;
+  let contextHintText  = '';
+
+  function showContextHint(text){
+    contextHintText  = text;
+    contextHintTimer = 4; // seconds to display (counted down in renderHUD via ~12 Hz)
+  }
 
   function renderHUD(){
     const { run, st, phase } = sim;
+
+    // Standard stat readouts.
     hudDist.textContent = fmtDist(Math.max(0, run.dist));
     if(state.perm.alti){
       altWrap.style.display = 'block';
@@ -93,15 +200,67 @@ export function createHudInput(deps){
       hudBurner.className = run.burnerUsed ? 'spent' : '';
     } else burnerWrap.style.display = 'none';
     ffBtn.classList.toggle('on', input.ff);
+
+    /* ── Haptic feedback on landings / bounces ── */
+    if(navigator.vibrate){
+      const bounceNow   = run.bounceCount ?? 0;
+      const slidingNow  = !!run.sliding;
+      if(bounceNow > _lastBounceCount){
+        // New bounce — short sharp pulse, scaled by impact severity.
+        navigator.vibrate(40);
+      } else if(slidingNow && !_lastSliding){
+        // Transition to sliding (landing) — two-pulse bump.
+        navigator.vibrate([30, 20, 60]);
+      }
+      _lastBounceCount = bounceNow;
+      _lastSliding     = slidingNow;
+    }
+
+    /* ── Contextual onboarding hints (first pull-up / stall / bounce) ── */
+    // Only fire on days 1-3 so veterans aren't nagged.
+    if(state.day <= 3 && phase === 'flight'){
+      if(!shownPullUp && run.vy > 2 && (state.lvl?.wings ?? 0) > 0){
+        shownPullUp = true;
+        showContextHint('Good pull! ⬆ hold to keep climbing, ease off before you stall');
+      } else if(!shownStall && (run.stalled ?? false)){
+        shownStall = true;
+        showContextHint('STALLED! ⬇ Dive to regain speed, then ease back up');
+      } else if(!shownBounce && (run.bounceCount ?? 0) > 0){
+        shownBounce = true;
+        showContextHint('Bounced! Each bounce costs distance — aim for a flat, low approach');
+      }
+    }
+
+    /* ── Hint display priority ── */
+    // 1. Paused overlay (set by togglePause; already written before renderHUD runs)
+    if(sim.paused) return; // keep PAUSED message as-is
+
+    // 2. Sliding skip hint.
     if(run.sliding){
-      hintEl.textContent = 'sliding… press ENTER to skip ahead';
+      // Reset context hint when we start sliding so it doesn't obscure the skip prompt.
+      contextHintTimer = 0;
+      hintEl.textContent = isCoarse
+        ? 'sliding… tap ⏩ to skip ahead'
+        : 'sliding… press ENTER to skip ahead';
       hintEl.style.display = 'block';
-    } else if(state.day <= 3 && phase==='flight'){
-      hintEl.textContent = state.lvl.wings>0
-        ? '⇧ pull up · ⇩ dive for speed' + (st.thrust>0 ? ' · SPACE rocket' : '') + (st.gunLevel>0 ? ' · C fire cannon' : '') + ' · F fast-forward'
-        : 'no wings yet… enjoy the flop';
+      return;
+    }
+
+    // 3. Contextual one-time call-outs.
+    if(contextHintTimer > 0){
+      contextHintTimer -= 0.08; // ~12 Hz tick = ~0.083 s per call
+      hintEl.textContent = contextHintText;
       hintEl.style.display = 'block';
-    } else hintEl.style.display = 'none';
+      return;
+    }
+
+    // 4. Persistent early-day flight hint.
+    if(state.day <= 3 && phase === 'flight'){
+      hintEl.textContent = flightHintText(st);
+      hintEl.style.display = 'block';
+    } else {
+      hintEl.style.display = 'none';
+    }
   }
 
   return { renderHUD };

--- a/assets/js/flightless-physics.js
+++ b/assets/js/flightless-physics.js
@@ -14,7 +14,7 @@ export function createPhysics(deps){
   const {
     sim, cam, state, input, SFX, save, popup, burst, fmtDist, fmtCash,
     clamp, lerp, angDiff, hash01, RAD, onFinishRun,
-    checkCollectibles, checkObstacles, checkRings, checkLandmarks,
+    checkCollectibles, checkObstacles, checkRings, checkLandmarks, checkPickups,
     MILESTONES, contractsFor,
   } = deps;
 
@@ -43,7 +43,10 @@ export function createPhysics(deps){
       mu,
       wingAuth: wings===0 ? 1.5 : 2.4 + 0.35*wings,         // pitch authority rad/s
       gMax:   4 + 0.9*L.struts,                             // structural load limit, g
-      thrust: L.rocket ? 10 + 8*L.rocket : 0,
+      // Diminishing returns: hyperbolic cap so high rocket levels still feel
+      // powerful but don't grow linearly forever.  Level 1→~17.6 m/s²;
+      // level 5→~47 m/s²; level 10→~61 m/s² (vs 90 with old linear formula).
+      thrust: L.rocket ? 10 + 8*L.rocket / (1 + 0.055*L.rocket) : 0,
       fuelMax:L.rocket ? 2 + 1.3*L.fuel : 0,
       sling,
       rest:   L.bounce ? 0.12 + 0.09*L.bounce : 0,
@@ -137,6 +140,17 @@ export function createPhysics(deps){
       obHits:0, smashCash:0, contractsMet:new Set(), contractT:0,
       contracts:contractsFor(state.day),   // locked in at launch
 
+      // overheat: accumulates while thrusting, dissipates at rest; triggers
+      // penalty above HEAT_MAX, auto-resets once cooled
+      heat:0, overheated:false,
+
+      // style/contract tracking
+      slideless:true,       // true until the first slide or bounce
+      lowAltTime:0,         // seconds spent airborne below LOW_ALT_M metres
+
+      // coast-on-fumes: set true at landing when fuel is nearly empty
+      coastOnFumes:false,
+
       msQueue: MILESTONES.map(m=>m[0]).filter(d=>!state.claimed.includes(d)),
     };
   }
@@ -150,6 +164,19 @@ export function createPhysics(deps){
   const SCALE_H = 8500;         // atmospheric scale height, m
   const A_STALL = 15*RAD;       // stall angle of attack
   const GLIDE_ANG = -7*RAD;     // hands-off trim seeks this shallow glide slope
+
+  // overheat: sustained rocket use risks a melt-down.
+  // heat climbs at 1/s while thrusting, cools at HEAT_COOL/s otherwise.
+  // Above HEAT_MAX the thrust is cut to HEAT_PENALTY fraction; a popup fires
+  // once. Once heat falls below HEAT_RESUME the penalty lifts.
+  const HEAT_RISE   = 1.0;      // heat units / s while thrusting
+  const HEAT_COOL   = 0.4;      // heat units / s while not thrusting
+  const HEAT_MAX    = 3.0;      // total seconds of sustained burn before penalty
+  const HEAT_RESUME = 1.5;      // hysteresis: penalty clears only once heat < this
+  const HEAT_PENALTY = 0.3;     // thrust fraction when overheated
+
+  // low-altitude tracking: time spent airborne below this height (metres)
+  const LOW_ALT_M = 50;
 
   // 0 below stall, 1 fully separated, smooth in between
   function stallBlend(aoa){
@@ -266,14 +293,35 @@ export function createPhysics(deps){
     sim.run.head = velA + clamp(aoa1 + clamp(aoaTgt-aoa1, -slew, slew), -0.9, 0.9);
 
     // ── forces (accelerations, m/s²) ──
-    let ax = 0, ay = -G;
+    // Daily-modifier wind: state.dailyMod is an optional object set by the
+    // data/store agent (daily modifier table). Read defensively — completely
+    // absent dailyMod or a missing .wind field is a guaranteed no-op.
+    const wind = state.dailyMod?.wind ?? 0;     // m/s² horizontal acceleration
+    const windY = state.dailyMod?.windY ?? 0;   // m/s² vertical (optional, e.g. updraft)
+    let ax = wind, ay = -G + windY;
 
     sim.run.thrusting = input.boost && sim.st.thrust>0 && sim.run.fuel>0;
     if(sim.run.thrusting){
       sim.run.fuel = Math.max(0, sim.run.fuel - h);
-      ax += Math.cos(sim.run.head)*sim.st.thrust;
-      ay += Math.sin(sim.run.head)*sim.st.thrust;
+      // ── overheat ── heat climbs while thrusting; cools when not
+      sim.run.heat = Math.min(sim.run.heat + HEAT_RISE*h, HEAT_MAX*1.5);
+      if(!sim.run.overheated && sim.run.heat >= HEAT_MAX){
+        sim.run.overheated = true;
+        popup('\u{1F321} OVERHEAT — thrust reduced!', 20);
+        cam.shake = Math.min(cam.shake + 4, 6);
+      }
+      const thrustEff = sim.run.overheated ? HEAT_PENALTY : 1.0;
+      ax += Math.cos(sim.run.head)*sim.st.thrust*thrustEff;
+      ay += Math.sin(sim.run.head)*sim.st.thrust*thrustEff;
       if(Math.random() < h*120) burst(sim.run.x - Math.cos(sim.run.head)*1.5, sim.run.y - Math.sin(sim.run.head)*1.5, 2, '#ff8c1a', 3, sim.run.head+Math.PI);
+      // extra heat-glow VFX when running hot
+      if(sim.run.overheated && Math.random() < h*60) burst(sim.run.x, sim.run.y, 1, '#ff3300', 4, sim.run.head+Math.PI);
+    } else {
+      // cool down when not thrusting
+      sim.run.heat = Math.max(0, sim.run.heat - HEAT_COOL*h);
+      if(sim.run.overheated && sim.run.heat < HEAT_RESUME){
+        sim.run.overheated = false;
+      }
     }
     SFX.setThrust(sim.run.thrusting);
 
@@ -322,17 +370,25 @@ export function createPhysics(deps){
         sim.run.vy = Math.max(impact*sim.st.rest, Math.min(impact*0.45, 2.0));
         sim.run.vx *= 0.94;
         sim.run.bounceCount++;
+        sim.run.slideless = false;   // touched ground — no longer slideless
         cam.shake = Math.min(10, impact*0.12);
         SFX.thump();
         burst(sim.run.x, 0.5, 10, '#cfe8ff', 5);
         if(sim.run.vy < 1.1){ sim.run.vy=0; sim.run.sliding=true; }
       } else {
         sim.run.vy=0; sim.run.vx*=0.75; sim.run.sliding=true;
+        sim.run.slideless = false;   // touched ground — no longer slideless
         cam.shake = Math.min(10, impact*0.15);
         SFX.thump();
         burst(sim.run.x, 0.5, 12, '#cfe8ff', 5);
       }
-      if(sim.run.sliding){ sim.run.thrusting=false; SFX.setThrust(false); }
+      if(sim.run.sliding){
+        sim.run.thrusting=false; SFX.setThrust(false);
+        // coast-on-fumes: reward landing nearly empty
+        if(sim.st.fuelMax > 0 && sim.run.fuel <= sim.st.fuelMax * 0.08){
+          sim.run.coastOnFumes = true;
+        }
+      }
     }
 
     // ── ice skimming ── hugging the deck at speed pays out: ground effect
@@ -354,9 +410,12 @@ export function createPhysics(deps){
     // records only count in the air, off the ramp
     sim.run.maxAlt = Math.max(sim.run.maxAlt, sim.run.y);
     sim.run.maxSpd = Math.max(sim.run.maxSpd, spNew);
+    // style tracking: time spent airborne and low (ground-hugger playstyle)
+    if(sim.run.y > 0.5 && sim.run.y < LOW_ALT_M) sim.run.lowAltTime += h;
     checkCollectibles();
     checkObstacles();
     checkRings();
+    if(checkPickups) checkPickups();
     checkLandmarks(spNew);
 
     // live contract completion — celebrate it the moment it happens

--- a/assets/js/flightless-render.js
+++ b/assets/js/flightless-render.js
@@ -15,15 +15,31 @@
 export function createRenderer(deps){
   const {
     sim, cam, state, input, ctx, w2sX, w2sY,
-    coinCluster, starPos, obstaclePos, ringPos,
+    coinCluster, starPos, obstaclePos, ringPos, pickupPos,
     LANDMARKS, SCALE_H,
     COIN_CELL, COIN_R, STAR_CELL, STAR_R, OBST_CELL, RING_CELL, RING_R,
+    PICKUP_CELL, PICKUP_R,
     fmtCash, hash01, clamp, lerp, RAD,
   } = deps;
 
+  /* ════════════════ reduced-motion helper ════════════════ */
+  // Check both the OS-level prefers-reduced-motion media query and the
+  // in-game settings toggle (read defensively so old saves work).
+  const _mqReduceMotion = (typeof window !== 'undefined' && window.matchMedia)
+    ? window.matchMedia('(prefers-reduced-motion: reduce)')
+    : null;
+  function isReducedMotion(){
+    const mq = _mqReduceMotion ? _mqReduceMotion.matches : false;
+    const st = state.settings?.reduceMotion ?? false;
+    return mq || st;
+  }
+
   /* ════════════════ particles / popups ════════════════ */
   function burst(x, y, n, color, spread, dirBias){
-    for(let i=0;i<n;i++){
+    // halve particle count when reduced-motion is on
+    const rm = isReducedMotion();
+    const count = rm ? Math.max(1, Math.floor(n * 0.35)) : n;
+    for(let i=0;i<count;i++){
       const a = dirBias!==undefined ? dirBias + (Math.random()-0.5)*0.9 : Math.random()*Math.PI*2;
       const s = Math.random()*spread;
       sim.particles.push({ x, y, vx:Math.cos(a)*s, vy:Math.sin(a)*s, life:0.5+Math.random()*0.5, color, size:0.15+Math.random()*0.3 });
@@ -36,6 +52,8 @@ export function createRenderer(deps){
       p.life -= dt; p.x += p.vx*dt; p.y += p.vy*dt; p.vy -= 4*dt;
       if(p.life<=0 || p.y<0) sim.particles.splice(i,1);
     }
+    // step ambient weather particles
+    stepAmbientParticles(dt);
   }
   /* ── speed streaks ──
      Short dashes anchored in WORLD space, seeded in the airspace ahead of the
@@ -52,7 +70,10 @@ export function createRenderer(deps){
     const t = clamp((sp-55)/140, 0, 1);
     if(t <= 0) return;
     const dir = Math.atan2(sim.run.vy, sim.run.vx);
-    const n = dt*(8 + 34*t);
+    // reduce speed line density when reduced-motion is on
+    const rm = isReducedMotion();
+    const densityScale = rm ? 0.25 : 1;
+    const n = dt*(8 + 34*t)*densityScale;
     let count = Math.floor(n) + (Math.random() < n-Math.floor(n) ? 1 : 0);
     const spanX = sim.W/cam.z, spanY = sim.Hpx/cam.z;
     while(count-- > 0){
@@ -78,13 +99,220 @@ export function createRenderer(deps){
     setTimeout(()=>el.remove(), 1700);
   }
 
+  /* ════════════════ debris system (landmark destruction) ════════════════ */
+  // Each debris chunk has its own physics and tumbles until it hits y=0.
+  // They live in sim.debris (created lazily so old saves don't break).
+  function ensureDebris(){
+    if(!sim.debris) sim.debris = [];
+  }
+  function spawnLandmarkDebris(x, y, lmId){
+    ensureDebris();
+    if(isReducedMotion()) return;
+    // color and shape varies per landmark
+    const palettes = {
+      snowman: ['#f4f8ff','#e0e8f0','#d0dce8','#ff8c1a'],
+      iceberg: ['#cfeaff','#8fc4e8','#a8d4f4','#e0f4ff'],
+      wall:    ['#a89c8e','#c2b6a6','#847a6f','#7a6e63'],
+    };
+    const colors = palettes[lmId] || palettes.wall;
+    const count = 18 + Math.floor(Math.random()*14);
+    for(let i=0;i<count;i++){
+      const a = (Math.random()*2-1)*Math.PI;
+      const spd = 18 + Math.random()*55;
+      sim.debris.push({
+        x, y,
+        vx: Math.cos(a)*spd,
+        vy: Math.sin(a)*spd + 15,   // slight upward bias
+        rot: Math.random()*Math.PI*2,
+        rotV: (Math.random()-0.5)*8,
+        w: 6 + Math.random()*18,
+        h: 4 + Math.random()*12,
+        color: colors[Math.floor(Math.random()*colors.length)],
+        life: 1.0,
+      });
+    }
+    if(sim.debris.length > 160) sim.debris.splice(0, sim.debris.length-160);
+  }
+  function stepDebris(dt){
+    ensureDebris();
+    for(let i=sim.debris.length-1;i>=0;i--){
+      const d = sim.debris[i];
+      d.x  += d.vx*dt; d.y  += d.vy*dt;
+      d.vy -= 28*dt;             // gravity
+      d.rot += d.rotV*dt;
+      d.life -= dt*0.6;
+      if(d.life <= 0 || d.y < -20) sim.debris.splice(i,1);
+    }
+  }
+  function drawDebris(){
+    ensureDebris();
+    if(!sim.debris.length) return;
+    for(const d of sim.debris){
+      const sx = w2sX(d.x), sy = w2sY(d.y);
+      if(sx<-80||sx>sim.W+80||sy<-80||sy>sim.Hpx+80) continue;
+      ctx.save();
+      ctx.globalAlpha = clamp(d.life, 0, 1);
+      ctx.translate(sx, sy);
+      ctx.rotate(d.rot);
+      ctx.fillStyle = d.color;
+      const sw = Math.max(2, d.w*cam.z*0.08);
+      const sh = Math.max(2, d.h*cam.z*0.08);
+      ctx.fillRect(-sw/2, -sh/2, sw, sh);
+      ctx.restore();
+    }
+    ctx.globalAlpha = 1;
+  }
+
+  /* ════════════════ ambient weather particles ════════════════ */
+  // Driven by state.dailyMod (read defensively). Kept in sim.ambient (lazy).
+  function ensureAmbient(){
+    if(!sim.ambient) sim.ambient = [];
+  }
+  // Return the current ambient mode: 'snow', 'aurora', or null.
+  function ambientMode(){
+    const mod = state.dailyMod ?? null;
+    if(!mod) return null;
+    if(mod === 'snow' || mod === 'blizzard') return 'snow';
+    if(mod === 'aurora') return 'aurora';
+    return null;
+  }
+  function stepAmbientParticles(dt){
+    ensureAmbient();
+    const mode = ambientMode();
+    if(!mode || isReducedMotion()){
+      sim.ambient.length = 0;
+      return;
+    }
+    // age existing
+    for(let i=sim.ambient.length-1;i>=0;i--){
+      const a = sim.ambient[i];
+      if(mode === 'snow'){
+        a.x  += (a.vx + sim.W*0.00003)*dt*60;
+        a.y  += a.vy*dt*60;
+        a.life -= dt*0.12;
+        if(a.y > sim.Hpx || a.life <= 0) sim.ambient.splice(i,1);
+      } else { // aurora ribbon
+        a.phase += dt*0.8;
+        a.life  -= dt*0.05;
+        if(a.life <= 0) sim.ambient.splice(i,1);
+      }
+    }
+    // spawn new
+    const maxP = 80;
+    if(mode === 'snow' && sim.ambient.length < maxP){
+      const toSpawn = Math.min(3, maxP - sim.ambient.length);
+      for(let i=0;i<toSpawn;i++){
+        sim.ambient.push({
+          x: Math.random()*sim.W,
+          y: -8,
+          vx: (Math.random()-0.5)*0.5,
+          vy: 0.4 + Math.random()*0.9,
+          r:  1 + Math.random()*2.5,
+          life: 1.0,
+        });
+      }
+    } else if(mode === 'aurora' && sim.ambient.length < 6){
+      sim.ambient.push({
+        x: Math.random()*sim.W,
+        baseY: 60 + Math.random()*sim.Hpx*0.25,
+        w: sim.W*(0.25 + Math.random()*0.4),
+        hue: 140 + Math.floor(Math.random()*80),
+        phase: Math.random()*Math.PI*2,
+        life: 1.0,
+      });
+    }
+  }
+  function drawAmbientParticles(){
+    ensureAmbient();
+    if(!sim.ambient.length) return;
+    const mode = ambientMode();
+    if(mode === 'snow'){
+      ctx.fillStyle = 'rgba(230,245,255,0.85)';
+      for(const a of sim.ambient){
+        ctx.globalAlpha = clamp(a.life*1.5, 0, 0.8);
+        ctx.beginPath();
+        ctx.arc(a.x, a.y, a.r, 0, 7);
+        ctx.fill();
+      }
+      ctx.globalAlpha = 1;
+    } else if(mode === 'aurora'){
+      for(const a of sim.ambient){
+        const amp = sim.Hpx*0.055;
+        const cy = a.baseY + Math.sin(a.phase + sim.timeSim*0.4)*amp;
+        const g = ctx.createLinearGradient(a.x - a.w/2, cy, a.x + a.w/2, cy);
+        const al = (clamp(a.life, 0, 1)*0.18).toFixed(3);
+        g.addColorStop(0,   `hsla(${a.hue},80%,60%,0)`);
+        g.addColorStop(0.3, `hsla(${a.hue},80%,65%,${al})`);
+        g.addColorStop(0.7, `hsla(${(a.hue+35)%360},85%,70%,${al})`);
+        g.addColorStop(1,   `hsla(${(a.hue+35)%360},80%,60%,0)`);
+        ctx.fillStyle = g;
+        ctx.beginPath();
+        ctx.ellipse(a.x, cy, a.w/2, sim.Hpx*0.07, 0, 0, 7);
+        ctx.fill();
+      }
+    }
+  }
+
   /* ════════════════ rendering ════════════════ */
+
+  // ── day/night sky palette ──
+  // The sky hue cycles over state.day: a dawn/day/dusk/night pattern that
+  // repeats with a 4-day period. All arithmetic is deterministic from state.day.
+  function dayPhase(){
+    // returns a float 0-1 representing position in a soft 4-day cycle
+    const day = (state.day ?? 0);
+    // 0 = cool dawn, 0.25 = bright noon, 0.5 = warm dusk, 0.75 = deep night
+    return (day % 4) / 4;
+  }
   function skyColor(alt){
-    const t = clamp(alt/8000, 0, 1);
-    const top =    [lerp(0x6d,0x02,t), lerp(0xb3,0x02,t), lerp(0xf2,0x10,t)];
-    const bottom = [lerp(0xae,0x0b,t), lerp(0xe4,0x10,t), lerp(0xff,0x30,t)];
+    const t = clamp(alt/8000, 0, 1);  // altitude factor (0=ground, 1=space)
+    const ph = dayPhase();
+
+    // Interpolate between four palette anchors (dawn/noon/dusk/night) in a
+    // smooth cycle. We store [topR,topG,topB, botR,botG,botB].
+    const palettes = [
+      // dawn  — warm pink/orange horizon, soft indigo top
+      [0x4a,0x5c,0xb8,  0xff,0xb0,0x60],
+      // noon  — classic sky blue
+      [0x6d,0xb3,0xf2,  0xae,0xe4,0xff],
+      // dusk  — deep violet top, amber horizon
+      [0x3a,0x28,0x7a,  0xff,0x7a,0x28],
+      // night — near-black top, deep blue horizon
+      [0x08,0x0a,0x28,  0x18,0x28,0x60],
+    ];
+    // smooth step through the 4 anchors
+    const seg = ph * 4;
+    const idx = Math.floor(seg) % 4;
+    const nxt = (idx + 1) % 4;
+    const frac = seg - Math.floor(seg);
+    const sm   = frac*frac*(3-2*frac);  // smoothstep
+
+    const pa = palettes[idx], pb = palettes[nxt];
+    const topR = lerp(pa[0], pb[0], sm);
+    const topG = lerp(pa[1], pb[1], sm);
+    const topB = lerp(pa[2], pb[2], sm);
+    const botR = lerp(pa[3], pb[3], sm);
+    const botG = lerp(pa[4], pb[4], sm);
+    const botB = lerp(pa[5], pb[5], sm);
+
+    // blend toward deep-space blue as altitude rises
+    const top = [lerp(topR,0x02,t), lerp(topG,0x02,t), lerp(topB,0x10,t)];
+    const bot = [lerp(botR,0x0b,t), lerp(botG,0x10,t), lerp(botB,0x30,t)];
     const rgb = c => `rgb(${c[0]|0},${c[1]|0},${c[2]|0})`;
-    return { top:rgb(top), bottom:rgb(bottom), space:t };
+    return { top:rgb(top), bottom:rgb(bot), space:t };
+  }
+
+  // ── ramp palette driven by day ──
+  function rampPalette(){
+    const day = state.day ?? 0;
+    const v = (day % 7);     // 7-day visual cycle
+    if(v < 1)      return { strut:'#7a4a21', track:'#a0622d', brace:'rgba(122,74,33,0.65)', snowCap:'#e8f4ff' };
+    else if(v < 2) return { strut:'#5a6a30', track:'#7a9040', brace:'rgba(90,106,48,0.65)', snowCap:'#d8f4c0' };
+    else if(v < 3) return { strut:'#5a3a7a', track:'#7a50a8', brace:'rgba(90,58,122,0.65)', snowCap:'#ecdcff' };
+    else if(v < 4) return { strut:'#2a5a6a', track:'#3a7a8a', brace:'rgba(42,90,106,0.65)', snowCap:'#c0ecf4' };
+    else if(v < 5) return { strut:'#8a4a2a', track:'#b85c30', brace:'rgba(138,74,42,0.65)', snowCap:'#f4d8c0' };
+    else if(v < 6) return { strut:'#1a4a5a', track:'#2a6a7a', brace:'rgba(26,74,90,0.65)',  snowCap:'#b0d8ec' };
+    else           return { strut:'#7a4a21', track:'#c07830', brace:'rgba(122,74,33,0.65)', snowCap:'#fff0c0' };
   }
 
   const stars = Array.from({length:130}, (_,i)=>({ x:hash01(i), y:hash01(i+500), r:0.5+hash01(i+900)*1.3 }));
@@ -151,6 +379,11 @@ export function createRenderer(deps){
     }
   }
 
+  // ── tracked landmark HP for detecting the kill transition ──
+  // We remember the previous HP value for each landmark so we can detect
+  // the exact frame it reaches 0 and spawn debris exactly once.
+  const _prevLmHP = {};
+
   function draw(dtReal){
     const p = sim.run || { x:0, y:0, vx:0, vy:0 };
     const sp = Math.hypot(p.vx, p.vy);
@@ -177,9 +410,13 @@ export function createRenderer(deps){
     cam.z = lerp(cam.z, tz, 1-Math.pow(0.02, dtReal));
     cam.x = lerp(cam.x, tx, 1-Math.pow(0.001, dtReal));
     cam.y = lerp(cam.y, ty, 1-Math.pow(0.001, dtReal));
+    const rm = isReducedMotion();
     let shx=0, shy=0;
-    if(cam.shake>0.2){
+    if(!rm && cam.shake>0.2){
       shx=(Math.random()-0.5)*cam.shake; shy=(Math.random()-0.5)*cam.shake;
+      cam.shake *= Math.pow(0.001, dtReal);
+    } else if(rm && cam.shake>0){
+      // still decay shake even if we're not applying it
       cam.shake *= Math.pow(0.001, dtReal);
     }
     ctx.save();
@@ -241,8 +478,12 @@ export function createRenderer(deps){
     // near clouds float in front of the ridges
     drawCloudLayer(sky.space, 0.85, 0.50, 520, 1.05, 3);
 
+    // ambient weather layer (snow / aurora)
+    drawAmbientParticles();
+
     drawCollectibles();
     drawRings();
+    drawPickups();
     drawObstacles();
 
     // ground
@@ -281,6 +522,7 @@ export function createRenderer(deps){
 
     drawLandmarks();
     drawRamp();
+    drawDebris();
 
     // flight trail — width & tint track speed so dives/climbs actually read as motion
     if(sim.run && sim.run.trail.length > 1){
@@ -345,9 +587,67 @@ export function createRenderer(deps){
         const rs = Math.max(cam.z*1.3, 13)*(1.35 - sim.run.y/110);
         ctx.beginPath(); ctx.ellipse(px, gy0+3, rs, rs*0.25, 0, 0, 7); ctx.fill();
       }
+
+      // ── speed/afterburner screen effect ──
+      // A full-screen vignette + optional chromatic aberration at high velocity
+      // or while thrusting. Implemented as cheap canvas post-effect:
+      //   1. Dark edge vignette that ramps with speed.
+      //   2. At very high speed: slight red/blue split drawn as two translucent
+      //      copies of the penguin's silhouette offset horizontally.
+      //   3. Translucent previous-frame smear when afterburner is active.
+      if(!rm){
+        const thrustOn = sim.run.thrusting ?? false;
+        const speedT   = clamp((sp - 120) / 280, 0, 1);
+        const effectT  = thrustOn ? clamp(speedT + 0.25, 0, 1) : speedT;
+
+        if(effectT > 0.01){
+          // vignette: radial gradient from transparent center to dark edge
+          const vg = ctx.createRadialGradient(
+            sim.W*0.5, sim.Hpx*0.5, sim.Hpx*0.1,
+            sim.W*0.5, sim.Hpx*0.5, Math.hypot(sim.W, sim.Hpx)*0.65
+          );
+          vg.addColorStop(0, 'rgba(0,0,0,0)');
+          vg.addColorStop(0.7, `rgba(0,0,10,${(effectT*0.18).toFixed(3)})`);
+          vg.addColorStop(1,   `rgba(0,0,20,${(effectT*0.45).toFixed(3)})`);
+          ctx.fillStyle = vg;
+          ctx.fillRect(0, 0, sim.W, sim.Hpx);
+
+          // lateral chromatic aberration: two faint colored bars near the
+          // center of the screen, simulating lens separation at high speed
+          if(speedT > 0.35){
+            const ca = clamp((speedT-0.35)/0.65, 0, 1);
+            const shift = ca * 6;
+            // red fringe left
+            ctx.fillStyle = `rgba(255,20,20,${(ca*0.07).toFixed(3)})`;
+            ctx.fillRect(-shift, 0, sim.W, sim.Hpx);
+            // blue fringe right
+            ctx.fillStyle = `rgba(20,60,255,${(ca*0.07).toFixed(3)})`;
+            ctx.fillRect(shift, 0, sim.W, sim.Hpx);
+          }
+
+          // horizontal motion lines across the screen at extreme speed
+          if(speedT > 0.6){
+            const mt = clamp((speedT-0.6)/0.4, 0, 1);
+            ctx.strokeStyle = `rgba(255,255,255,${(mt*0.06).toFixed(3)})`;
+            ctx.lineWidth = 1;
+            const lineCount = Math.floor(mt * 12);
+            for(let li=0; li<lineCount; li++){
+              const ly2 = (li/(lineCount-1||1)) * sim.Hpx;
+              ctx.beginPath();
+              ctx.moveTo(0, ly2);
+              ctx.lineTo(sim.W, ly2 + (Math.random()-0.5)*3);
+              ctx.stroke();
+            }
+          }
+        }
+      }
+
       drawPenguin(px, py, sim.run.head + sim.run.tumble, Math.max(cam.z*1.3, 13));
     }
     ctx.restore();
+
+    // step debris physics after restoring ctx so translations don't carry over
+    stepDebris(dtReal);
   }
 
   function drawFishIcon(x, y, s, gold){
@@ -489,7 +789,20 @@ export function createRenderer(deps){
       const sx = w2sX(lm.x);
       const wpx = Math.max(lm.w*cam.z, 8), hpx = lm.h*cam.z;
       if(sx < -wpx*3-160 || sx > sim.W+wpx*3+160) continue;
-      const dead = state.lmHP[lm.id] <= 0;
+
+      // detect fresh kill → spawn debris
+      const curHP  = state.lmHP[lm.id] ?? lm.hp;
+      const prevHP = _prevLmHP[lm.id] ?? lm.hp;
+      if(prevHP > 0 && curHP <= 0){
+        // landmark just died this frame — big debris burst
+        const worldY = lm.h * 0.3;   // mid-height of the structure
+        spawnLandmarkDebris(lm.x, worldY, lm.id);
+        // second burst at base
+        spawnLandmarkDebris(lm.x, 0, lm.id);
+      }
+      _prevLmHP[lm.id] = curHP;
+
+      const dead = curHP <= 0;
       if(lm.id === 'snowman'){
         ctx.fillStyle = '#f4f8ff';
         if(dead){
@@ -574,13 +887,14 @@ export function createRenderer(deps){
   function drawRamp(){
     if(!sim.ramp) return;
     const pts = sim.ramp.pts;
+    const pal = rampPalette();
     // support struts with diagonal cross-bracing
-    ctx.strokeStyle = '#7a4a21'; ctx.lineWidth = Math.max(1.5, cam.z*0.35);
+    ctx.strokeStyle = pal.strut; ctx.lineWidth = Math.max(1.5, cam.z*0.35);
     for(let i=0;i<pts.length;i+=6){
       const sx = w2sX(pts[i].x);
       ctx.beginPath(); ctx.moveTo(sx, w2sY(pts[i].y)); ctx.lineTo(sx, w2sY(0)); ctx.stroke();
     }
-    ctx.strokeStyle = 'rgba(122,74,33,0.65)'; ctx.lineWidth = Math.max(1, cam.z*0.2);
+    ctx.strokeStyle = pal.brace; ctx.lineWidth = Math.max(1, cam.z*0.2);
     for(let i=0;i+6<pts.length;i+=6){
       const a = pts[i], b = pts[i+6];
       ctx.beginPath();
@@ -591,12 +905,12 @@ export function createRenderer(deps){
       ctx.stroke();
     }
     // track
-    ctx.strokeStyle = '#a0622d'; ctx.lineWidth = Math.max(3, cam.z*0.7);
+    ctx.strokeStyle = pal.track; ctx.lineWidth = Math.max(3, cam.z*0.7);
     ctx.beginPath();
     ctx.moveTo(w2sX(pts[0].x), w2sY(pts[0].y));
     for(const p of pts) ctx.lineTo(w2sX(p.x), w2sY(p.y));
     ctx.stroke();
-    ctx.strokeStyle = '#e8f4ff'; ctx.lineWidth = Math.max(1.2, cam.z*0.25);
+    ctx.strokeStyle = pal.snowCap; ctx.lineWidth = Math.max(1.2, cam.z*0.25);
     ctx.beginPath();
     ctx.moveTo(w2sX(pts[0].x), w2sY(pts[0].y));
     for(const p of pts) ctx.lineTo(w2sX(p.x), w2sY(p.y));
@@ -606,6 +920,7 @@ export function createRenderer(deps){
     const fx = w2sX(top.x), fy = w2sY(top.y);
     ctx.strokeStyle = '#ddd'; ctx.lineWidth = 2;
     ctx.beginPath(); ctx.moveTo(fx, fy); ctx.lineTo(fx, fy-26); ctx.stroke();
+    // flag color cycles with day using the same palette key
     ctx.fillStyle = '#FF0000';
     ctx.beginPath(); ctx.moveTo(fx, fy-26); ctx.lineTo(fx+20, fy-20); ctx.lineTo(fx, fy-14); ctx.fill();
   }
@@ -806,11 +1121,58 @@ export function createRenderer(deps){
     }
   }
 
+  // fuel/boost canisters (world.js places them; keys are 'pk'+cellIndex)
+  function drawPickupIcon(x, y, s, type){
+    const bob = Math.sin(sim.timeSim*3 + x*0.04)*s*0.18;
+    ctx.save();
+    ctx.translate(x, y + bob);
+    const glow = type===0 ? 'rgba(79,195,247,0.28)' : 'rgba(255,152,0,0.30)';
+    ctx.fillStyle = glow;
+    ctx.beginPath(); ctx.arc(0, 0, s*1.8, 0, 7); ctx.fill();
+    if(type===0){
+      // fuel canister — rounded blue can with a cap and a droplet mark
+      ctx.fillStyle = '#2f9fd0';
+      ctx.fillRect(-s*0.6, -s*0.8, s*1.2, s*1.6);
+      ctx.fillStyle = '#4fc3f7';
+      ctx.fillRect(-s*0.6, -s*0.8, s*1.2, s*0.5);
+      ctx.fillStyle = '#e8f6ff';
+      ctx.beginPath(); ctx.arc(0, s*0.15, s*0.32, 0, 7); ctx.fill();
+      ctx.fillStyle = '#1c6f96';
+      ctx.fillRect(-s*0.28, -s*1.02, s*0.56, s*0.24);
+    } else {
+      // speed boost — orange lightning chevrons
+      ctx.fillStyle = '#ff9800';
+      ctx.beginPath(); ctx.arc(0, 0, s*0.9, 0, 7); ctx.fill();
+      ctx.strokeStyle = '#fff3d0'; ctx.lineWidth = Math.max(1.5, s*0.16); ctx.lineJoin='round';
+      ctx.beginPath();
+      ctx.moveTo(s*0.28, -s*0.7); ctx.lineTo(-s*0.28, s*0.05);
+      ctx.lineTo(s*0.08, s*0.05); ctx.lineTo(-s*0.28, s*0.72);
+      ctx.stroke();
+    }
+    ctx.restore();
+  }
+  function drawPickups(){
+    if(!sim.run || typeof pickupPos !== 'function' || !PICKUP_CELL) return;
+    const i0 = Math.floor((cam.x - sim.W/cam.z)/PICKUP_CELL)-1, i1 = Math.ceil((cam.x + sim.W/cam.z)/PICKUP_CELL)+1;
+    for(let i=i0;i<=i1;i++){
+      if(sim.run.collected.has('pk'+i)) continue;
+      const p = pickupPos(i);
+      if(!p) continue;
+      const sx=w2sX(p.x), sy=w2sY(p.y);
+      if(sx<-80||sx>sim.W+80||sy<-80||sy>sim.Hpx+80) continue;
+      drawPickupIcon(sx, sy, clamp((PICKUP_R||18)*cam.z*0.7, 12, 26), p.type);
+    }
+  }
+
   return {
     burst, stepParticles, stepSpeedLines, popup,
     draw, drawRamp, gliderName, drawGlider, drawPenguin,
     drawFishIcon, drawStarIcon, drawCollectibles,
     drawBird, drawBalloon, drawPlane, drawObstacles,
     drawLandmarks, drawRingIcon, drawRings, skyColor,
+    // new helpers added by this revision:
+    spawnLandmarkDebris,   // call from world.js or host for a boss-kill burst
+    isReducedMotion,       // expose so other modules can query it
+    rampPalette,           // expose for potential shop background use
   };
 }

--- a/assets/js/flightless-results.js
+++ b/assets/js/flightless-results.js
@@ -10,6 +10,97 @@ export function createResults(deps){
 
   const clamp = (v,a,b) => v<a?a : v>b?b : v;
 
+  // ── Headline flavor tables ──────────────────────────────────────────────
+  // Multiple variants per distance tier. Picked deterministically by state.day
+  // so a given day's headline is stable (no jitter on revisit).
+  const HEADLINES = [
+    { max:   30, lines:[
+      'THAT WAS… A START',
+      'OFF TO A SLOW START',
+      'BARELY OFF THE RAMP',
+      'THE RAMP MISSES YOU',
+      'SPLAT. TRY AGAIN.',
+    ]},
+    { max:  200, lines:[
+      'GETTING SOMEWHERE',
+      'A RESPECTABLE WOBBLE',
+      'YOU BRIEFLY FLEW',
+      'AIRBORNE. SORT OF.',
+      'PROGRESS. POSSIBLY.',
+    ]},
+    { max: 1000, lines:[
+      'NOW WE\'RE FLYING',
+      'THE HORIZON BECKONS',
+      'DECENT LIFTOFF!',
+      'THE WIND IS WILLING',
+      'FEATHERS AND FURY',
+    ]},
+    { max: 8000, lines:[
+      'INCREDIBLE FLIGHT',
+      'THE CROWD GOES WILD',
+      'SOARING IN STYLE',
+      'HEIGHTS UNCHARTED',
+      'A MASTERCLASS LAUNCH',
+    ]},
+    { max: Infinity, lines:[
+      'ABSOLUTELY LEGENDARY',
+      'PENGUIN HISTORY MADE',
+      'THEY\'LL WRITE SONGS',
+      'THE WALL TREMBLES',
+      'MAXIMUM VELOCITY BIRD',
+    ]},
+  ];
+
+  function pickHeadline(dist, day){
+    const tier = HEADLINES.find(t => dist < t.max) || HEADLINES[HEADLINES.length-1];
+    return tier.lines[day % tier.lines.length];
+  }
+
+  // ── Sponsor-patience meter ──────────────────────────────────────────────
+  // state.sponsorPatience is a 0–100 integer (read defensively; save.js will
+  // seed it eventually, but we default to 100 until then).
+  //
+  // Design goals:
+  //   • Weak flights (< 100 m) bleed patience noticeably.
+  //   • Mid flights (100–1 000 m) are roughly neutral with a slight drain.
+  //   • Strong flights (1 000+ m) recover patience.
+  //   • Each unmet contract drops an extra 5; each met contract restores 3.
+  //   • Full patience (100) awards a bonus cash row worth 10 % of subtotal.
+  //   • Meter never goes below 0 or above 100.
+  //   • Even a string of flops takes ~7–8 bad runs to empty (forgiving early).
+
+  function calcPatienceDelta(dist, contractResults){
+    let delta = 0;
+    if(dist < 30)         delta = -15;
+    else if(dist < 100)   delta = -10;
+    else if(dist < 300)   delta =  -5;
+    else if(dist < 1000)  delta =  -2;
+    else if(dist < 5000)  delta =   4;
+    else if(dist < 15000) delta =   8;
+    else                  delta =  12;
+
+    for(const c of contractResults){
+      delta += c.met ? 3 : -5;
+    }
+    return delta;
+  }
+
+  function patienceLabel(p){
+    if(p >= 90) return '★ ECSTATIC';
+    if(p >= 70) return 'ENTHUSIASTIC';
+    if(p >= 50) return 'SATISFIED';
+    if(p >= 30) return 'IMPATIENT';
+    if(p >= 10) return 'LOSING FAITH';
+    return '⚠ FURIOUS';
+  }
+
+  function patienceColor(p){
+    if(p >= 70) return 'var(--yellow)';
+    if(p >= 40) return 'var(--cash)';
+    return 'var(--red, #e05)';
+  }
+
+  // ── Count-up animation ──────────────────────────────────────────────────
   let countUpTimers = [];
   function animateCash(el, target, delay, dur){
     el.textContent = '$0';
@@ -56,8 +147,21 @@ export function createResults(deps){
       ({ ...c, got:c.val(sim.run), met:sim.run.contractsMet.has(i) || c.val(sim.run) >= c.target }));
     const contractTotal = contractResults.reduce((sum,c) => sum + (c.met ? c.reward : 0), 0);
     const skimCash = Math.round(sim.run.skimCash);
+
+    // ── Sponsor-patience scoring ──────────────────────────────────────────
+    const prevPatience = state.sponsorPatience ?? 100;
+    const delta = calcPatienceDelta(dist, contractResults);
+    const newPatience = clamp(prevPatience + delta, 0, 100);
+    state.sponsorPatience = newPatience;
+
+    // Full-patience bonus: 10 % of subtotal when meter is at 100 heading in
+    const fullPatienceBonus = prevPatience >= 100
+      ? Math.round(subtotal * 0.10)
+      : 0;
+
     const total = Math.round(subtotal + bonusTotal + contractTotal + sim.run.smashCash
-      + sim.run.coinCash + sim.run.starCash + sim.run.gunCash + sim.run.ringCash + skimCash);
+      + sim.run.coinCash + sim.run.starCash + sim.run.gunCash + sim.run.ringCash
+      + skimCash + fullPatienceBonus);
     state.money += total;
 
     const recD = dist > state.best.dist, recA = sim.run.maxAlt > state.best.alt, recS = sim.run.maxSpd > state.best.spd;
@@ -72,12 +176,15 @@ export function createResults(deps){
       if(m.chk(sim.run)){ state.medals.push(m.id); state.bp += m.bp; newMedals.push(m); }
     }
 
+    // ── Sound barks (guarded — SFX.cheer/oof may not exist yet) ──────────
+    const isRecord = recD || recA || recS || newMedals.length > 0;
+    const isCrash  = dist < 30;
+    if(isRecord && typeof SFX.cheer === 'function') SFX.cheer();
+    if(isCrash  && typeof SFX.oof   === 'function') SFX.oof();
+
+    // ── DOM ───────────────────────────────────────────────────────────────
     document.getElementById('res-day').textContent = state.day;
-    const headline = dist < 30 ? 'THAT WAS… A START' :
-                     dist < 200 ? 'GETTING SOMEWHERE' :
-                     dist < 1000 ? 'NOW WE’RE FLYING' :
-                     dist < 8000 ? 'INCREDIBLE FLIGHT' : 'ABSOLUTELY LEGENDARY';
-    document.getElementById('res-headline').textContent = headline;
+    document.getElementById('res-headline').textContent = pickHeadline(dist, state.day);
     document.getElementById('res-dist').textContent = fmtDist(dist);
     document.getElementById('res-alt').textContent = fmtDist(sim.run.maxAlt);
     document.getElementById('res-spd').textContent = Math.round(sim.run.maxSpd)+' m/s';
@@ -100,6 +207,8 @@ export function createResults(deps){
 
     const bonusBox = document.getElementById('res-bonuses');
     bonusBox.innerHTML = '';
+
+    // Milestones
     newBonuses.forEach(([d, cash], i) => {
       const row = document.createElement('div');
       row.className = 'res-row bonus';
@@ -108,6 +217,8 @@ export function createResults(deps){
       animateCash(row.querySelector('.cash'), cash, 1300+i*250, 500);
     });
     if(newBonuses.length) setTimeout(()=>SFX.ding(), 1300);
+
+    // Demolition bonus
     if(sim.run.smashCash > 0){
       const row = document.createElement('div');
       row.className = 'res-row bonus';
@@ -115,6 +226,8 @@ export function createResults(deps){
       bonusBox.appendChild(row);
       animateCash(row.querySelector('.cash'), sim.run.smashCash, 1350, 600);
     }
+
+    // Medals
     newMedals.forEach((m, i) => {
       const row = document.createElement('div');
       row.className = 'res-row bonus';
@@ -122,6 +235,8 @@ export function createResults(deps){
       bonusBox.appendChild(row);
     });
     if(newMedals.length) setTimeout(()=>SFX.ding(), 1500);
+
+    // Contracts
     contractResults.forEach((c, i) => {
       const row = document.createElement('div');
       row.className = 'res-row' + (c.met ? ' bonus' : '');
@@ -134,6 +249,33 @@ export function createResults(deps){
         bonusBox.appendChild(row);
       }
     });
+
+    // Sponsor patience row — always shown so players can track the meter
+    {
+      const arrow  = delta >= 0 ? '▲' : '▼';
+      const label  = patienceLabel(newPatience);
+      const color  = patienceColor(newPatience);
+      const bar    = '█'.repeat(Math.round(newPatience / 10)) + '░'.repeat(10 - Math.round(newPatience / 10));
+      const row = document.createElement('div');
+      row.className = 'res-row';
+      row.innerHTML =
+        `<span class="val" style="color:${color}">` +
+          `📣 Sponsor mood: ${label} ${arrow}${Math.abs(delta)}` +
+        `</span>` +
+        `<span class="cash" style="color:${color};letter-spacing:1px;font-size:11px">${bar}</span>`;
+      bonusBox.appendChild(row);
+    }
+
+    // Full-patience bonus row
+    if(fullPatienceBonus > 0){
+      const row = document.createElement('div');
+      row.className = 'res-row bonus';
+      row.innerHTML = `<span class="val">🎉 Perfect sponsor rating!</span><span class="cash"></span>`;
+      bonusBox.appendChild(row);
+      const delay = 1400 + contractResults.length * 250;
+      animateCash(row.querySelector('.cash'), fullPatienceBonus, delay, 500);
+      setTimeout(()=>SFX.ding(), delay);
+    }
 
     animateCash(document.getElementById('cash-dist'), Math.round(cashDist*payMult), 200, 700);
     const altCashEl = document.getElementById('cash-alt');

--- a/assets/js/flightless-save.js
+++ b/assets/js/flightless-save.js
@@ -4,52 +4,231 @@
 // localStorage, and persisting it back. No game logic lives here — just
 // the schema and its defaults, so it can evolve (new fields, migrations)
 // independently of the sim and UI that read/write it.
-const SAVE_KEY = 'flightless-save-v1';
+//
+// Schema versioning: state.version is an integer.  Any save without a version
+// field is treated as version 0. MIGRATIONS is an ordered array; entry [i]
+// upgrades a version-i save to version-(i+1). Add a new function to the end
+// whenever the schema changes — never edit an existing migration.
+//
+// Export surface (public API — signatures are frozen):
+//   defaultState()            → plain state object at current schema version
+//   loadState()               → loads/sanitizes from localStorage
+//   saveState(state)          → persists to localStorage
+//   exportSave()              → base64 JSON string (dependency-free)
+//   importSave(str)           → validated state object, or throws
+
+const SAVE_KEY    = 'flightless-save-v1';
+const SCHEMA_VER  = 1;   // increment each time a migration is appended
+
+// ─── helpers ────────────────────────────────────────────────────────────────
+
+function clamp(v, lo, hi){ return Math.min(Math.max(v, lo), hi); }
+function finite(v, fallback){ return (typeof v === 'number' && isFinite(v)) ? v : fallback; }
+function bool(v, fallback){ return typeof v === 'boolean' ? v : fallback; }
+
+// ─── schema ─────────────────────────────────────────────────────────────────
 
 export function defaultState(){
   return {
-    money:0, day:1, lvl:{ramp:0,aero:0,wings:0,rocket:0,fuel:0,sling:0,bounce:0,sponsor:0,gun:0,struts:0,plating:0},
-    perm:{speedo:false,alti:false,burner:false,tank:false},
-    best:{dist:0,alt:0,spd:0}, claimed:[], won:false, muted:false, started:false,
+    version: SCHEMA_VER,
+    money: 0, day: 1,
+    lvl: { ramp:0, aero:0, wings:0, rocket:0, fuel:0, sling:0, bounce:0, sponsor:0, gun:0, struts:0, plating:0 },
+    perm: { speedo:false, alti:false, burner:false, tank:false },
+    best: { dist:0, alt:0, spd:0 },
+    claimed: [], won: false, muted: false, started: false,
+    // new forward-looking fields (consumed defensively by sound/render/html)
+    musicMuted: false,
+    settings: { reduceMotion:false, sfxVol:1, musicVol:1 },
+    ngPlus: 0,
+    sponsorPatience: 100,
     // landmark hit points (persist between days), medals earned, bonus points,
     // and permanent bonus-shop levels (these three survive a progress reset)
-    lmHP:{snowman:400, iceberg:2500, wall:12000},
-    medals:[], bp:0, bonus:{aero:0, cash:0, skull:0},
+    // NOTE: these MUST match the `hp` values in flightless-data.js's LANDMARKS
+    // table — lmHP is the persisted *current* HP, seeded to each landmark's max.
+    lmHP: { snowman:350, iceberg:2000, wall:8000 },
+    medals: [], bp: 0, bonus: { aero:0, cash:0, skull:0 },
     // ramp spline control points in unit shape space (gate → lip); the last
     // point IS the lip. Upgrades buy track length; this is the shape of it.
-    rampShape:[{x:0.03,y:0.95},{x:0.16,y:0.32},{x:0.72,y:0.02},{x:1,y:0.10}],
+    rampShape: [{x:0.03,y:0.95},{x:0.16,y:0.32},{x:0.72,y:0.02},{x:1,y:0.10}],
   };
 }
+
+// ─── migrations ─────────────────────────────────────────────────────────────
+// Each entry upgrades from version N → N+1.
+// MIGRATIONS[0] upgrades a version-0 save (legacy, no version field) to v1.
+
+const MIGRATIONS = [
+  // v0 → v1: seed forward-looking fields that were absent in legacy saves.
+  function migrateV0toV1(s){
+    if(typeof s.musicMuted !== 'boolean') s.musicMuted = false;
+    if(!s.settings || typeof s.settings !== 'object') s.settings = {};
+    if(typeof s.settings.reduceMotion !== 'boolean') s.settings.reduceMotion = false;
+    if(typeof s.settings.sfxVol   !== 'number') s.settings.sfxVol   = 1;
+    if(typeof s.settings.musicVol !== 'number') s.settings.musicVol = 1;
+    if(typeof s.ngPlus !== 'number') s.ngPlus = 0;
+    if(typeof s.sponsorPatience !== 'number') s.sponsorPatience = 100;
+    s.version = 1;
+    return s;
+  },
+  // Future: append migrateV1toV2, etc. here.
+];
+
+/** Apply all pending migrations to a raw parsed object. */
+function applyMigrations(s){
+  const from = (typeof s.version === 'number' && isFinite(s.version))
+    ? Math.max(0, Math.floor(s.version))
+    : 0;
+  for(let v = from; v < MIGRATIONS.length; v++){
+    s = MIGRATIONS[v](s);
+  }
+  return s;
+}
+
+// ─── sanitization ───────────────────────────────────────────────────────────
+// Called after migrations so every field is in its post-migration shape.
+
+const KNOWN_LVL_KEYS   = new Set(['ramp','aero','wings','rocket','fuel','sling','bounce','sponsor','gun','struts','plating']);
+const KNOWN_PERM_KEYS  = new Set(['speedo','alti','burner','tank']);
+const KNOWN_BEST_KEYS  = new Set(['dist','alt','spd']);
+const KNOWN_LMHP_KEYS  = new Set(['snowman','iceberg','wall']);
+const KNOWN_BONUS_KEYS = new Set(['aero','cash','skull']);
+const KNOWN_SETTINGS_KEYS = new Set(['reduceMotion','sfxVol','musicVol']);
+
+// Top-level keys that belong in a saved state.
+const KNOWN_TOP_KEYS = new Set([
+  'version','money','day','lvl','perm','best','claimed','won','muted',
+  'started','musicMuted','settings','ngPlus','sponsorPatience',
+  'lmHP','medals','bp','bonus','rampShape',
+]);
+
+function sanitize(state){
+  const d = defaultState();
+
+  // Drop unknown top-level keys.
+  for(const k of Object.keys(state)){
+    if(!KNOWN_TOP_KEYS.has(k)) delete state[k];
+  }
+
+  // Scalars
+  state.version        = SCHEMA_VER;
+  state.money          = clamp(finite(state.money,          0), 0, 1e12);
+  state.day            = clamp(finite(state.day,            1), 1, 1e6);
+  state.bp             = clamp(finite(state.bp,             0), 0, 1e9);
+  state.ngPlus         = clamp(finite(state.ngPlus,         0), 0, 999);
+  state.sponsorPatience= clamp(finite(state.sponsorPatience,100), 0, 100);
+  state.won            = bool(state.won,     false);
+  state.muted          = bool(state.muted,   false);
+  state.musicMuted     = bool(state.musicMuted, false);
+  state.started        = bool(state.started, false);
+
+  // Arrays
+  if(!Array.isArray(state.claimed)) state.claimed = [];
+  if(!Array.isArray(state.medals))  state.medals  = [];
+
+  // Sub-objects: keep known keys only, clamp/coerce values.
+  state.lvl = Object.fromEntries(
+    Array.from(KNOWN_LVL_KEYS).map(k => [k, clamp(finite(state.lvl?.[k], 0), 0, 100)])
+  );
+  state.perm = Object.fromEntries(
+    Array.from(KNOWN_PERM_KEYS).map(k => [k, bool(state.perm?.[k], false)])
+  );
+  state.best = Object.fromEntries(
+    Array.from(KNOWN_BEST_KEYS).map(k => [k, clamp(finite(state.best?.[k], 0), 0, 1e9)])
+  );
+  state.lmHP = Object.fromEntries(
+    Array.from(KNOWN_LMHP_KEYS).map(k => [k, clamp(finite(state.lmHP?.[k], d.lmHP[k]), 0, 1e7)])
+  );
+  state.bonus = Object.fromEntries(
+    Array.from(KNOWN_BONUS_KEYS).map(k => [k, clamp(finite(state.bonus?.[k], 0), 0, 1e6)])
+  );
+
+  // Settings sub-object
+  if(!state.settings || typeof state.settings !== 'object') state.settings = {};
+  state.settings = Object.fromEntries(
+    Array.from(KNOWN_SETTINGS_KEYS).map(k => {
+      if(k === 'reduceMotion') return [k, bool(state.settings[k], false)];
+      return [k, clamp(finite(state.settings[k], 1), 0, 1)];
+    })
+  );
+
+  // rampShape: legacy 3-point saves get the missing lip appended.
+  if(Array.isArray(state.rampShape) && state.rampShape.length === 3)
+    state.rampShape = [...state.rampShape, {x:1, y:0.10}];
+  if(
+    !Array.isArray(state.rampShape) ||
+    state.rampShape.length !== 4 ||
+    state.rampShape.some(p => !p || typeof p.x !== 'number' || typeof p.y !== 'number' ||
+                              !isFinite(p.x) || !isFinite(p.y))
+  ){
+    state.rampShape = d.rampShape;
+  } else {
+    state.rampShape = state.rampShape.map(p => ({
+      x: clamp(p.x, 0, 1),
+      y: clamp(p.y, 0.02, 1),
+    }));
+  }
+
+  // pre-gear saves: skip the intro if they've clearly played before.
+  state.started = state.started || state.day > 1 || state.best.dist > 0;
+
+  return state;
+}
+
+// ─── public API ─────────────────────────────────────────────────────────────
 
 export function loadState(){
   let state = defaultState();
   try{
     const raw = localStorage.getItem(SAVE_KEY);
     if(raw){
-      const s = JSON.parse(raw);
-      state = Object.assign(defaultState(), s);
-      state.lvl = Object.assign(defaultState().lvl, s.lvl||{});
-      state.perm = Object.assign(defaultState().perm, s.perm||{});
-      state.best = Object.assign(defaultState().best, s.best||{});
-      state.lmHP = Object.assign(defaultState().lmHP, s.lmHP||{});
-      state.bonus = Object.assign(defaultState().bonus, s.bonus||{});
-      if(!Array.isArray(state.medals)) state.medals = [];
-      if(typeof state.bp !== 'number' || !isFinite(state.bp)) state.bp = 0;
-      // sanitize the ramp spline (older saves stored a nose angle, or a
-      // 3-point shape with an implicit fixed lip — append the old lip)
-      if(Array.isArray(state.rampShape) && state.rampShape.length===3)
-        state.rampShape = [...state.rampShape, {x:1, y:0.10}];
-      if(!Array.isArray(state.rampShape) || state.rampShape.length!==4 ||
-         state.rampShape.some(p=>!p || typeof p.x!=='number' || typeof p.y!=='number' || !isFinite(p.x) || !isFinite(p.y)))
-        state.rampShape = defaultState().rampShape;
-      else state.rampShape = state.rampShape.map(p=>({ x:Math.min(Math.max(p.x,0),1), y:Math.min(Math.max(p.y,0.02),1) }));
-      // pre-gear saves: skip the intro if they've clearly played before
-      state.started = state.started || state.day>1 || state.best.dist>0;
+      const parsed = JSON.parse(raw);
+      if(parsed && typeof parsed === 'object'){
+        const migrated = applyMigrations(parsed);
+        state = sanitize(Object.assign(defaultState(), migrated));
+      }
     }
-  }catch(e){ /* corrupted save -> fresh start */ }
+  }catch(e){ /* corrupted save → fresh start */ }
   return state;
 }
 
 export function saveState(state){
   try{ localStorage.setItem(SAVE_KEY, JSON.stringify(state)); }catch(e){}
+}
+
+/**
+ * exportSave() → base64-encoded JSON string of the current save.
+ * Dependency-free; works in any browser context. The store wires a button
+ * to this; call saveState() first so the export reflects the latest state.
+ */
+export function exportSave(){
+  const raw = localStorage.getItem(SAVE_KEY) ?? JSON.stringify(defaultState());
+  return btoa(unescape(encodeURIComponent(raw)));
+}
+
+/**
+ * importSave(str) → validated state object.
+ * Throws a descriptive Error if the string is not valid base64 JSON or fails
+ * schema validation. The caller (store UI) is responsible for writing the
+ * returned state back via saveState() and re-loading the page.
+ */
+export function importSave(str){
+  if(typeof str !== 'string' || !str.trim())
+    throw new Error('importSave: empty input');
+  let json;
+  try{
+    json = decodeURIComponent(escape(atob(str.trim())));
+  }catch(e){
+    throw new Error('importSave: invalid base64');
+  }
+  let parsed;
+  try{
+    parsed = JSON.parse(json);
+  }catch(e){
+    throw new Error('importSave: invalid JSON');
+  }
+  if(!parsed || typeof parsed !== 'object' || Array.isArray(parsed))
+    throw new Error('importSave: root must be an object');
+  const migrated  = applyMigrations(parsed);
+  const validated = sanitize(Object.assign(defaultState(), migrated));
+  return validated;
 }

--- a/assets/js/flightless-sound.js
+++ b/assets/js/flightless-sound.js
@@ -5,30 +5,103 @@
 // named cues (ding/tick/thump/boom/launch) the sim and UI call by name.
 // Takes the save state so it can respect the mute flag without the rest
 // of the game reaching into its internals.
+//
+// NEW in this revision:
+//   setEngine(speed)  — engine-hum oscillator layer, pitch/gain tracks speed
+//   thump(intensity)  — optional 0-1 intensity arg (defaults 1); legacy call
+//                       thump() unchanged
+//   thumpSoft()       — light landing thud
+//   thumpHard()       — heavy impact thud
+//   flap()            — quick wing-flap tick
+//   cheer()           — milestone/record bark (results agent)
+//   oof()             — crash bark (results agent)
+//   startMusic()      — begin looping synth-arpeggio bed
+//   stopMusic()       — fade out and stop music
+//   setMusicVolume(v) — 0-1 master music gain
+//
+// Music is gated on state.musicMuted (read defensively) INDEPENDENTLY of
+// state.muted (SFX). SFX muting never touches the music gain node and vice
+// versa. Neither audio path starts until ensure() runs (user-gesture path).
 export function createSound(state){
   const SFX = {
-    ctx:null, thrustGain:null,
+    ctx: null,
+    thrustGain: null,
+    thrustFilt: null,
+
+    // Engine-hum oscillator layer (setEngine)
+    engineOsc: null,
+    engineGain: null,
+
+    // Background music
+    musicGain: null,
+    musicOscNodes: [],   // running arp oscillators
+    musicNextTime: 0,    // scheduler lookahead cursor
+    musicTimerId: null,  // setInterval id for arp scheduler
+    musicRunning: false,
+
+    // ---- CORE INIT -------------------------------------------------------
+
     ensure(){
       if(state.muted) return null;
       if(!this.ctx){
         try{ this.ctx = new (window.AudioContext||window.webkitAudioContext)(); }catch(e){ return null; }
-        // looping noise buffer for the rocket
-        const len = this.ctx.sampleRate * 0.5;
-        const buf = this.ctx.createBuffer(1, len, this.ctx.sampleRate);
-        const d = buf.getChannelData(0);
-        for(let i=0;i<len;i++) d[i] = Math.random()*2-1;
-        const src = this.ctx.createBufferSource();
-        src.buffer = buf; src.loop = true;
-        const filt = this.ctx.createBiquadFilter();
-        filt.type='lowpass'; filt.frequency.value = 500;
-        this.thrustGain = this.ctx.createGain();
-        this.thrustGain.gain.value = 0;
-        src.connect(filt); filt.connect(this.thrustGain); this.thrustGain.connect(this.ctx.destination);
-        src.start();
+        this._initNoise();
+        this._initEngine();
       }
       if(this.ctx.state==='suspended') this.ctx.resume();
       return this.ctx;
     },
+
+    // ensure() path that does NOT gate on state.muted — used by music so it
+    // can play even when SFX is muted (they are independent flags).
+    _ensureCtx(){
+      if(!this.ctx){
+        try{ this.ctx = new (window.AudioContext||window.webkitAudioContext)(); }catch(e){ return null; }
+        this._initNoise();
+        this._initEngine();
+      }
+      if(this.ctx.state==='suspended') this.ctx.resume();
+      return this.ctx;
+    },
+
+    // Looping filtered-noise buffer for rocket thrust bed.
+    _initNoise(){
+      const c = this.ctx;
+      const len = c.sampleRate * 0.5;
+      const buf = c.createBuffer(1, len, c.sampleRate);
+      const d = buf.getChannelData(0);
+      for(let i=0;i<len;i++) d[i] = Math.random()*2-1;
+      const src = c.createBufferSource();
+      src.buffer = buf; src.loop = true;
+      this.thrustFilt = c.createBiquadFilter();
+      this.thrustFilt.type = 'lowpass'; this.thrustFilt.frequency.value = 500;
+      this.thrustGain = c.createGain();
+      this.thrustGain.gain.value = 0;
+      src.connect(this.thrustFilt);
+      this.thrustFilt.connect(this.thrustGain);
+      this.thrustGain.connect(c.destination);
+      src.start();
+    },
+
+    // Engine-hum oscillator layer (sawtooth, pitches with speed).
+    _initEngine(){
+      const c = this.ctx;
+      this.engineOsc = c.createOscillator();
+      this.engineOsc.type = 'sawtooth';
+      this.engineOsc.frequency.value = 80;
+      // gentle low-pass so it blends with noise bed
+      const filt = c.createBiquadFilter();
+      filt.type = 'lowpass'; filt.frequency.value = 400;
+      this.engineGain = c.createGain();
+      this.engineGain.gain.value = 0;
+      this.engineOsc.connect(filt);
+      filt.connect(this.engineGain);
+      this.engineGain.connect(c.destination);
+      this.engineOsc.start();
+    },
+
+    // ---- EXISTING SFX (UNCHANGED API) ------------------------------------
+
     blip(freq, dur, type, vol){
       const c = this.ensure(); if(!c) return;
       const o = c.createOscillator(), g = c.createGain();
@@ -38,24 +111,187 @@ export function createSound(state){
       o.connect(g); g.connect(c.destination);
       o.start(); o.stop(c.currentTime + (dur||0.1) + 0.02);
     },
+
     launch(){
       const c = this.ensure(); if(!c) return;
       const o = c.createOscillator(), g = c.createGain();
-      o.type='sawtooth';
+      o.type = 'sawtooth';
       o.frequency.setValueAtTime(120, c.currentTime);
       o.frequency.exponentialRampToValueAtTime(700, c.currentTime+0.5);
       g.gain.setValueAtTime(0.1, c.currentTime);
       g.gain.exponentialRampToValueAtTime(0.0001, c.currentTime+0.6);
       o.connect(g); g.connect(c.destination); o.start(); o.stop(c.currentTime+0.7);
     },
+
     ding(){ this.blip(880,0.15,'sine',0.1); setTimeout(()=>this.blip(1320,0.25,'sine',0.1), 110); },
     tick(){ this.blip(1400,0.03,'square',0.03); },
     buy(){ this.blip(660,0.08,'square',0.06); setTimeout(()=>this.blip(990,0.1,'square',0.06), 70); },
-    thump(){ this.blip(90,0.15,'sine',0.15); },
+
+    // thump — now accepts optional intensity 0-1 (defaults to 1 for backwards
+    // compat). All existing call sites that pass no arg continue to work.
+    thump(intensity){
+      const v = (intensity == null ? 1 : Math.max(0, Math.min(1, intensity)));
+      const c = this.ensure(); if(!c) return;
+      const o = c.createOscillator(), g = c.createGain();
+      o.type = 'sine';
+      // pitch drops with lighter impacts so softer hits sound lighter
+      const baseFreq = 60 + 30 * v;
+      o.frequency.setValueAtTime(baseFreq, c.currentTime);
+      o.frequency.exponentialRampToValueAtTime(30, c.currentTime+0.18);
+      g.gain.setValueAtTime(0.08 + 0.14*v, c.currentTime);
+      g.gain.exponentialRampToValueAtTime(0.0001, c.currentTime+0.18);
+      o.connect(g); g.connect(c.destination); o.start(); o.stop(c.currentTime+0.22);
+    },
+
     boom(){ this.blip(55,0.5,'sawtooth',0.22); this.blip(220,0.25,'square',0.1); },
+
     setThrust(on){
-      if(state.muted || !this.thrustGain) { if(this.thrustGain) this.thrustGain.gain.value=0; return; }
+      if(state.muted || !this.thrustGain){ if(this.thrustGain) this.thrustGain.gain.value=0; return; }
       this.thrustGain.gain.setTargetAtTime(on?0.12:0, this.ctx.currentTime, 0.05);
+    },
+
+    // ---- NEW SFX ---------------------------------------------------------
+
+    // setEngine(speed): drive engine-hum layer. speed is 0-1 normalized or raw
+    // m/s — treat anything ≥1 as a raw speed (cap at ~200 m/s).
+    // Pitch range 80–320 Hz, gain 0–0.07.
+    setEngine(speed){
+      if(!this.engineGain || !this.engineOsc) return;
+      if(state.muted){ this.engineGain.gain.value = 0; return; }
+      // normalise: values > 1 treated as m/s (max ~200)
+      const t = speed > 1 ? Math.min(speed / 200, 1) : Math.max(0, Math.min(speed, 1));
+      const freq = 80 + 240 * t;        // 80 Hz idle → 320 Hz full throttle
+      const gain = 0.07 * t;
+      const now = this.ctx ? this.ctx.currentTime : 0;
+      this.engineOsc.frequency.setTargetAtTime(freq, now, 0.1);
+      this.engineGain.gain.setTargetAtTime(gain, now, 0.1);
+    },
+
+    // thumpSoft / thumpHard — named wrappers around thump(intensity)
+    thumpSoft(){ this.thump(0.3); },
+    thumpHard(){ this.thump(1.0); },
+
+    // flap — quick wing-beat; higher-pitched short noise burst
+    flap(){
+      const c = this.ensure(); if(!c) return;
+      // short noise burst filtered to mid-range for a feathery whoosh
+      const len = Math.floor(c.sampleRate * 0.06);
+      const buf = c.createBuffer(1, len, c.sampleRate);
+      const d = buf.getChannelData(0);
+      for(let i=0;i<len;i++) d[i] = (Math.random()*2-1) * (1 - i/len);
+      const src = c.createBufferSource();
+      src.buffer = buf;
+      const filt = c.createBiquadFilter();
+      filt.type = 'bandpass'; filt.frequency.value = 1800; filt.Q.value = 1.2;
+      const g = c.createGain();
+      g.gain.setValueAtTime(0.07, c.currentTime);
+      g.gain.exponentialRampToValueAtTime(0.0001, c.currentTime+0.07);
+      src.connect(filt); filt.connect(g); g.connect(c.destination);
+      src.start(); src.stop(c.currentTime+0.08);
+    },
+
+    // cheer — ascending trill for milestone / record
+    cheer(){
+      const c = this.ensure(); if(!c) return;
+      const notes = [523, 659, 784, 1047];
+      notes.forEach((f,i)=>{
+        setTimeout(()=>this.blip(f, 0.12, 'sine', 0.09), i*70);
+      });
+    },
+
+    // oof — descending grunt for crash
+    oof(){
+      const c = this.ensure(); if(!c) return;
+      const notes = [330, 220, 165];
+      notes.forEach((f,i)=>{
+        setTimeout(()=>this.blip(f, 0.14, 'sawtooth', 0.07), i*60);
+      });
+    },
+
+    // ---- BACKGROUND MUSIC -----------------------------------------------
+    //
+    // A lightweight procedural synth bed: a short arpeggio pattern scheduled
+    // in a lookahead loop (Web Audio best-practice). Uses its OWN gain node
+    // so state.musicMuted gates it entirely independently of state.muted.
+    //
+    // C minor pentatonic: C3 Eb3 F3 G3 Bb3 C4
+    _ARP_NOTES: [130.81, 155.56, 174.61, 196.00, 233.08, 261.63],
+    _ARP_PATTERN: [0, 2, 4, 3, 1, 4, 2, 5],  // indices into _ARP_NOTES
+    _ARP_STEP_SEC: 0.22,
+    _ARP_STEP_IDX: 0,
+
+    _scheduleMusicNote(time){
+      if(!this.musicGain || !this.ctx) return;
+      const notes = this._ARP_NOTES;
+      const pat   = this._ARP_PATTERN;
+      const freq  = notes[pat[this._ARP_STEP_IDX % pat.length]];
+      this._ARP_STEP_IDX++;
+
+      // pad layer — sine at root freq for warmth
+      const pad = this.ctx.createOscillator();
+      pad.type = 'sine'; pad.frequency.value = freq * 0.5;
+      const padG = this.ctx.createGain();
+      padG.gain.setValueAtTime(0, time);
+      padG.gain.linearRampToValueAtTime(0.04, time + 0.04);
+      padG.gain.setValueAtTime(0.04, time + this._ARP_STEP_SEC * 2.5);
+      padG.gain.linearRampToValueAtTime(0, time + this._ARP_STEP_SEC * 3.5);
+      pad.connect(padG); padG.connect(this.musicGain);
+      pad.start(time); pad.stop(time + this._ARP_STEP_SEC * 4);
+
+      // arp note — triangle, one step duration
+      const arp = this.ctx.createOscillator();
+      arp.type = 'triangle'; arp.frequency.value = freq;
+      const arpG = this.ctx.createGain();
+      arpG.gain.setValueAtTime(0.06, time);
+      arpG.gain.exponentialRampToValueAtTime(0.0001, time + this._ARP_STEP_SEC * 0.85);
+      arp.connect(arpG); arpG.connect(this.musicGain);
+      arp.start(time); arp.stop(time + this._ARP_STEP_SEC);
+    },
+
+    _musicTick(){
+      if(!this.ctx || !this.musicRunning) return;
+      const LOOKAHEAD = 0.3; // seconds ahead to schedule
+      while(this.musicNextTime < this.ctx.currentTime + LOOKAHEAD){
+        this._scheduleMusicNote(this.musicNextTime);
+        this.musicNextTime += this._ARP_STEP_SEC;
+      }
+    },
+
+    startMusic(){
+      // Gate: don't start if music is muted
+      if(state.musicMuted ?? false) return;
+      if(this.musicRunning) return;
+      // Bring up AudioContext even if SFX is muted (music is independent)
+      const c = this._ensureCtx(); if(!c) return;
+      if(!this.musicGain){
+        this.musicGain = c.createGain();
+        this.musicGain.gain.value = 0.5;
+        this.musicGain.connect(c.destination);
+      }
+      this.musicRunning = true;
+      this.musicNextTime = c.currentTime + 0.05;
+      this._ARP_STEP_IDX = 0;
+      this.musicTimerId = setInterval(()=>this._musicTick(), 100);
+      this._musicTick();
+    },
+
+    stopMusic(){
+      if(!this.musicRunning) return;
+      this.musicRunning = false;
+      if(this.musicTimerId != null){ clearInterval(this.musicTimerId); this.musicTimerId = null; }
+      // Fade out quickly to avoid click
+      if(this.musicGain && this.ctx){
+        const now = this.ctx.currentTime;
+        this.musicGain.gain.setTargetAtTime(0, now, 0.3);
+      }
+    },
+
+    // v: 0-1
+    setMusicVolume(v){
+      const vol = Math.max(0, Math.min(1, v));
+      if(this.musicGain && this.ctx){
+        this.musicGain.gain.setTargetAtTime(vol * 0.5, this.ctx.currentTime, 0.05);
+      }
     },
   };
   return SFX;

--- a/assets/js/flightless-store.js
+++ b/assets/js/flightless-store.js
@@ -17,6 +17,20 @@ export function createStore(deps){
     getSt, getRamp, recompute, sampleShape, clamp, RAD,
   } = deps;
 
+  // Defensive reads for optional deps that may arrive in a future save/data
+  // agent pass.  Never throw if absent — just no-op the feature.
+  const dailyDealFor = typeof deps.dailyDealFor === 'function' ? deps.dailyDealFor : null;
+  const exportSave   = typeof deps.save?.exportSave === 'function'
+    ? () => deps.save.exportSave()
+    : typeof deps.exportSave === 'function'
+      ? deps.exportSave
+      : null;
+  const importSave   = typeof deps.save?.importSave === 'function'
+    ? s => deps.save.importSave(s)
+    : typeof deps.importSave === 'function'
+      ? deps.importSave
+      : null;
+
   const shopGrid = document.getElementById('shop-grid');
   const gearGrid = document.getElementById('gear-grid');
   const bonusGrid = document.getElementById('bonus-grid');
@@ -66,6 +80,75 @@ export function createStore(deps){
   const edX = p => ED_PAD + p.x*(ED_W-2*ED_PAD);
   const edY = p => ED_GROUND - p.y*(ED_GROUND-ED_TOP);
   let edDrag = -1;
+
+  // ── ramp designer presets ──
+  // Preset control-point arrays: each entry is a full rampShape replacement.
+  // Points are in normalised [0,1]×[0,1] coordinates matching the editor's
+  // convention: x increases left→right along the ramp base, y=0 is ground
+  // level and y=1 is the top of the editor canvas.
+  const RAMP_PRESETS = [
+    {
+      label: '🚀 Steep Launch',
+      // Gate high, kicker near the end, lip shoots near-vertical.
+      shape: [
+        { x: 0.08, y: 0.82 },
+        { x: 0.38, y: 0.65 },
+        { x: 0.68, y: 0.38 },
+        { x: 0.92, y: 0.14 },
+      ],
+    },
+    {
+      label: '🪂 Long Glide',
+      // Gentle ramp for maximum horizontal carry rather than altitude.
+      shape: [
+        { x: 0.06, y: 0.55 },
+        { x: 0.32, y: 0.42 },
+        { x: 0.62, y: 0.28 },
+        { x: 0.94, y: 0.18 },
+      ],
+    },
+    {
+      label: '🛹 Trick Ramp',
+      // Mid-height kicker with a sharp upswing at the lip for combos/style.
+      shape: [
+        { x: 0.07, y: 0.45 },
+        { x: 0.28, y: 0.35 },
+        { x: 0.60, y: 0.50 },
+        { x: 0.90, y: 0.22 },
+      ],
+    },
+  ];
+
+  // Build the preset button row and append it into #ramp-pop (above the
+  // canvas) so the DOM order is: presets → canvas → footer.
+  const presetRow = document.createElement('div');
+  presetRow.style.cssText = 'display:flex;gap:4px;justify-content:center;flex-wrap:wrap;margin-bottom:2px;';
+  for(const preset of RAMP_PRESETS){
+    const btn = document.createElement('button');
+    btn.textContent = preset.label;
+    btn.style.cssText = [
+      'font-family:inherit',
+      'font-size:10px',
+      'cursor:pointer',
+      'background:var(--panel)',
+      'color:var(--text)',
+      'border:1px solid var(--border)',
+      'padding:3px 7px',
+      'border-radius:3px',
+    ].join(';');
+    btn.addEventListener('mouseenter', () => { btn.style.borderColor = 'var(--yellow)'; });
+    btn.addEventListener('mouseleave', () => { btn.style.borderColor = 'var(--border)'; });
+    btn.addEventListener('click', () => {
+      // Deep-copy the preset so later drags don't mutate our constant.
+      state.rampShape = preset.shape.map(p => ({ ...p }));
+      recompute();
+      save();
+      drawEditor();
+    });
+    presetRow.appendChild(btn);
+  }
+  // Insert before the canvas (first child of ramp-pop).
+  rampPop.insertBefore(presetRow, rampPop.firstChild);
 
   function drawEditor(){
     const ramp = getRamp();
@@ -172,6 +255,68 @@ export function createStore(deps){
     drawEditor();
   });
 
+  // ── save export / import UI ──
+  // Wire export/import buttons into the shop footer's notes area (next to the
+  // reset link).  The buttons are no-ops if save.exportSave/importSave are not
+  // provided — guarded above at module top.
+  (function buildSaveButtons(){
+    const notesEl = document.querySelector('#shop .notes');
+    if(!notesEl) return;   // DOM not yet ready somehow; skip gracefully
+
+    const row = document.createElement('div');
+    row.style.cssText = 'display:flex;gap:10px;margin-top:2px;';
+
+    if(exportSave){
+      const exportBtn = document.createElement('button');
+      exportBtn.className = 'reset-link';
+      exportBtn.textContent = '📋 export save';
+      exportBtn.title = 'Copy save data to clipboard';
+      exportBtn.addEventListener('click', async () => {
+        try {
+          const str = exportSave();
+          if(typeof str !== 'string' || !str) return;
+          await navigator.clipboard.writeText(str);
+          exportBtn.textContent = '✅ copied!';
+          setTimeout(() => { exportBtn.textContent = '📋 export save'; }, 2000);
+        } catch(err) {
+          // Clipboard can be blocked; fall back to a prompt the user can copy from.
+          const str = exportSave();
+          if(str) prompt('Copy this save string:', str);
+        }
+      });
+      row.appendChild(exportBtn);
+    }
+
+    if(importSave){
+      const importBtn = document.createElement('button');
+      importBtn.className = 'reset-link';
+      importBtn.textContent = '📥 import save';
+      importBtn.title = 'Paste a save string to restore progress';
+      importBtn.addEventListener('click', () => {
+        const str = prompt('Paste your save string:');
+        if(!str) return;
+        try {
+          const imported = importSave(str.trim());
+          if(!imported || typeof imported !== 'object') throw new Error('empty save');
+          // Apply IN PLACE — every module holds a reference to this same
+          // `state` object, so reassigning it would leave them reading a stale
+          // copy. Mirror the reset-progress flow in the host page.
+          for(const k of Object.keys(state)) delete state[k];
+          Object.assign(state, imported);
+          save();
+          // Reload the shop to reflect the new state.
+          recompute();
+          renderShop();
+        } catch(err) {
+          alert('Import failed — save string may be invalid.\n' + (err?.message ?? err));
+        }
+      });
+      row.appendChild(importBtn);
+    }
+
+    if(row.childElementCount > 0) notesEl.appendChild(row);
+  })();
+
   function renderShop(){
     drawEditor();
     document.getElementById('shop-money').textContent = fmtCash(state.money);
@@ -210,6 +355,12 @@ export function createStore(deps){
       goalList.appendChild(li);
     }
 
+    // ── daily deal resolution (defensive: dailyDealFor may be absent) ──
+    const todaysDeal = dailyDealFor ? (function(){
+      try { return dailyDealFor(state.day); } catch(_){ return null; }
+    })() : null;
+    // todaysDeal is expected to be { id, discount } — e.g. { id: 'engine', discount: 0.25 }
+
     // upgrade cards — unlock at distance milestones; a maxed-out upgrade drops
     // off the list entirely (its slot is free for a later "tier 2" upgrade),
     // and a fresh one you can't afford yet stays hidden too, except the single
@@ -222,22 +373,57 @@ export function createStore(deps){
     let upgAffordable = 0;
     for(const u of upgAvail){
       const lvl = state.lvl[u.id];
-      const cost = upgCost(u);
+      const baseCost = upgCost(u);
+
+      // Apply daily deal discount if this upgrade matches today's deal.
+      const isDailyDeal = todaysDeal && todaysDeal.id === u.id;
+      const dealDiscount = isDailyDeal && typeof todaysDeal.discount === 'number'
+        ? clamp(todaysDeal.discount, 0, 0.9)
+        : 0;
+      const cost = isDailyDeal ? Math.max(1, Math.round(baseCost * (1 - dealDiscount))) : baseCost;
+
       const locked = u.requires && state.lvl[u.requires] === 0;
       if(!locked && lvl===0 && state.money < cost && u !== cheapestNewUpg) continue;
       const affordable = !locked && state.money >= cost;
       if(affordable) upgAffordable++;
       const card = document.createElement('div');
-      card.className = 'upg' + (affordable ? ' affordable' : '');
+      card.className = 'upg' + (affordable ? ' affordable' : '') + (isDailyDeal ? ' daily-deal' : '');
+
+      // ── stat projection ladder ──
+      // Show current value plus up to 3 preview levels so the player can see
+      // the full trajectory, not just the immediate next step.
+      const projSteps = [];
+      for(let step = 1; step <= 3; step++){
+        const previewLvl = lvl + step;
+        if(previewLvl > u.max) break;
+        projSteps.push({ lvl: previewLvl, val: u.val(previewLvl) });
+      }
+      // Build a small "ladder" string: "→ v1 → v2 → v3"
+      const ladderHTML = projSteps
+        .map((s, i) => {
+          const isNext = i === 0;
+          const color  = isNext ? 'var(--yellow)' : '#8891d8';
+          return `<span style="color:${color};font-weight:${isNext?'bold':'normal'}">${s.val}</span>`;
+        })
+        .join('<span style="color:var(--muted)"> → </span>');
+
       const pips = Array.from({length:u.max}, (_,i)=>`<div class="pip${i<lvl?' on':''}"></div>`).join('');
-      const nextVal = ` → <b style="color:var(--yellow)">${u.val(lvl+1)}</b>`;
+
+      // Daily deal badge styling injected inline so it works without a CSS edit.
+      const dealBadgeHTML = isDailyDeal
+        ? `<div style="font-size:9px;font-weight:bold;color:#ff0;background:#500;padding:1px 5px;border-radius:2px;margin-bottom:3px;display:inline-block;">
+             ⚡ DAILY DEAL −${Math.round(dealDiscount*100)}%
+           </div><br>`
+        : '';
+
       card.innerHTML = `
         <div class="upg-head"><span class="upg-icon">${u.icon}</span><span class="upg-name">${u.name}</span></div>
+        ${dealBadgeHTML}
         <div class="upg-desc">${u.desc}</div>
-        <div class="upg-stat">${u.val(lvl)}${nextVal}</div>
+        <div class="upg-stat">${u.val(lvl)}${ladderHTML ? `<span style="color:var(--muted)"> → </span>${ladderHTML}` : ''}</div>
         <div class="pips">${pips}</div>
         ${locked ? `<div class="locked-note">requires ${UPGRADES.find(x=>x.id===u.requires).name}</div>` : ''}
-        <button ${(locked || state.money<cost)?'disabled':''}>Buy — ${fmtCash(cost)}</button>`;
+        <button ${(locked || state.money<cost)?'disabled':''}>${isDailyDeal ? `Deal — ${fmtCash(cost)}` : `Buy — ${fmtCash(cost)}`}${isDailyDeal && baseCost !== cost ? ` <s style="color:var(--muted);font-size:9px">${fmtCash(baseCost)}</s>` : ''}</button>`;
       card.querySelector('button').addEventListener('click', () => {
         if(state.money < cost || locked) return;
         state.money -= cost;
@@ -267,7 +453,7 @@ export function createStore(deps){
     bonusGrid.innerHTML = '';
     let bonusAffordable = 0;
     for(const b of BONUS_SHOP){
-      const lvl = state.bonus[b.id];
+      const lvl = state.bonus[b.id] ?? 0;
       const maxed = lvl >= b.max;
       const cost = maxed ? 0 : b.cost[lvl];
       const affordable = !maxed && state.bp >= cost;
@@ -275,20 +461,48 @@ export function createStore(deps){
       const card = document.createElement('div');
       card.className = 'upg gear' + (affordable ? ' affordable' : '');
       const pips = Array.from({length:b.max}, (_,i)=>`<div class="pip${i<lvl?' on':''}"></div>`).join('');
+
+      // ── bonus respec: refund button (50% BP back per level) ──
+      // Only show refund when at least one level has been bought.
+      const refundPerLevel = Math.floor((b.cost[0] ?? 1) * 0.5);
+      const totalRefund    = lvl > 0 ? lvl * refundPerLevel : 0;
+      const refundHTML = lvl > 0
+        ? `<button class="bonus-refund" style="font-family:inherit;font-size:9.5px;cursor:pointer;background:none;border:none;color:#e87;text-decoration:underline;padding:0;margin-top:2px;" title="Refund all levels for ${totalRefund} BP (50% per level)">↩ refund (${totalRefund} BP)</button>`
+        : '';
+
       card.innerHTML = `
         <div class="upg-head"><span class="upg-icon">${b.icon}</span><span class="upg-name">${b.name}</span></div>
         <div class="upg-desc">${b.desc}</div>
         <div class="pips">${pips}</div>
+        ${refundHTML}
         <button ${(maxed || state.bp < cost)?'disabled':''}>${maxed ? 'MAX' : `Buy — ${cost} BP`}</button>`;
-      card.querySelector('button').addEventListener('click', () => {
+
+      card.querySelector('button:last-of-type').addEventListener('click', () => {
         if(maxed || state.bp < cost) return;
         state.bp -= cost;
-        state.bonus[b.id]++;
+        state.bonus[b.id] = (state.bonus[b.id] ?? 0) + 1;
         SFX.buy();
         save();
         renderShop();
         recompute();
       });
+
+      // Wire refund button if it exists.
+      const refundBtn = card.querySelector('.bonus-refund');
+      if(refundBtn){
+        refundBtn.addEventListener('click', () => {
+          const curLvl = state.bonus[b.id] ?? 0;
+          if(curLvl <= 0) return;
+          const refund = curLvl * refundPerLevel;
+          state.bp += refund;
+          state.bonus[b.id] = 0;
+          SFX.buy();
+          save();
+          renderShop();
+          recompute();
+        });
+      }
+
       bonusGrid.appendChild(card);
     }
     setTabCount('bonus', bonusAffordable);

--- a/assets/js/flightless-world.js
+++ b/assets/js/flightless-world.js
@@ -1,12 +1,13 @@
 // Flightless — world objects module.
 //
 // Everything the penguin can fly into that isn't the ice itself: fish/star
-// collectibles, bird/balloon/plane obstacles, boost rings, and the landmark
-// bosses. All of it uses the same deterministic-cell-grid trick (hash01 of
-// the cell index decides existence/type/position), so only the on-screen
-// cells ever need to be considered instead of storing every object placed
-// along a 35 km flight. Reads and mutates sim.run/sim.st/sim.phase — the
-// shared flight state that's reassigned each flight by the physics module.
+// collectibles, bird/balloon/plane obstacles, boost rings, landmark bosses,
+// and fuel/boost pickups. All of it uses the same deterministic-cell-grid
+// trick (hash01 of the cell index decides existence/type/position), so only
+// the on-screen cells ever need to be considered instead of storing every
+// object placed along a 35 km flight. Reads and mutates sim.run/sim.st/
+// sim.phase — the shared flight state that's reassigned each flight by the
+// physics module.
 export function createWorld(deps){
   const { sim, cam, state, SFX, save, popup, burst, fmtCash,
           hash01, clamp, LANDMARKS, OBSTACLE_TYPES } = deps;
@@ -44,7 +45,9 @@ export function createWorld(deps){
   }
 
   // ── combo chain ── collecting anything within 3 s of the last pickup
-  // multiplies its value; the chain resets when the clock runs out
+  // multiplies its value; the chain resets when the clock runs out.
+  // Gun-kills and landmark hits also feed this chain so a hot streak
+  // (gun blasts + smashing a landmark face) feels connected.
   function comboMult(){
     sim.run.combo = sim.run.comboT > 0 ? sim.run.combo+1 : 1;
     sim.run.comboT = 3;
@@ -164,8 +167,12 @@ export function createWorld(deps){
     const {i, o} = best;
     if(o.type.tough <= sim.st.gunLevel){
       sim.run.obGone.add('o'+i);
-      sim.run.gunCash += o.type.cash; sim.run.gunKills++;
-      popup(`\u{1F4A5} ${o.type.id} down! +${fmtCash(o.type.cash)}`, 20);
+      sim.run.gunKills++;
+      // gun kills feed the combo chain
+      const m = comboMult();
+      const val = Math.round(o.type.cash * m);
+      sim.run.gunCash += val;
+      popup(`\u{1F4A5} ${o.type.id} down! +${fmtCash(val)}${sim.run.combo>1?` ×${sim.run.combo}`:''}`, 20);
       SFX.boom();
       cam.shake = Math.min(cam.shake+6, 16);
       burst(o.x, o.y, 22, '#ffae42', 12);
@@ -207,46 +214,264 @@ export function createWorld(deps){
     }
   }
 
-  /* ════════════════ landmarks ════════════════ */
-  // Physical bosses standing on the ice. Fly into one to damage it — the hurt
-  // persists between days — and bring it down for a payout. The Wall is the
-  // real victory condition. You CAN fly over them, but they won't forget you.
-  function checkLandmarks(spNew){
-    for(const lm of LANDMARKS){
-      if(state.lmHP[lm.id] <= 0) continue;
-      const face = lm.x - lm.w*0.5;
-      if(sim.run.vx > 0 && sim.run.y < lm.h && sim.run.x >= face && sim.run.x <= lm.x + lm.w){
-        const dmg = Math.max(1, Math.round(spNew * sim.st.smash));
-        state.lmHP[lm.id] = Math.max(0, state.lmHP[lm.id] - dmg);
-        if(state.lmHP[lm.id] <= 0){
-          sim.run.smashCash += lm.reward;
-          popup(`\u{1F4A5} ${lm.name} DESTROYED! +${fmtCash(lm.reward)}`, 30);
-          SFX.boom();
-          cam.shake = 16;
-          burst(lm.x, Math.min(sim.run.y+10, lm.h*0.6), 40, lm.color, 18);
-          sim.run.vx *= 0.7;               // smash straight through the wreckage
+  /* ════════════════ fuel / boost pickups ════════════════ */
+  // Canisters on the deterministic cell grid: blue = fuel refill, orange =
+  // short speed boost. Rendered by the render module via the exported *Pos()
+  // helpers and cell constants below.
+  const PICKUP_CELL = 550;
+  // type 0 = fuel canister (blue), type 1 = speed boost (orange)
+  function pickupPos(i){
+    if(i < 1) return null;
+    // ~35 % of cells have a pickup; split ~60/40 fuel/boost
+    if(hash01(i*83+19) < 0.65) return null;
+    const x = i*PICKUP_CELL + 50 + hash01(i*13+7)*(PICKUP_CELL-100);
+    const top = Math.max(corridorTop(x)*0.85, 30);
+    const y = 20 + Math.pow(hash01(i*37+53), 1.5)*(top-20);
+    const type = hash01(i*61+29) < 0.6 ? 0 : 1;  // 0=fuel, 1=boost
+    return { x, y, type };
+  }
+  const PICKUP_R = 18;
+  function checkPickups(){
+    // no pickups if rocket not installed (fuel would be wasted)
+    const pi = Math.round(sim.run.x/PICKUP_CELL);
+    for(let di=-1; di<=1; di++){
+      const i = pi+di, key = 'pk'+i;
+      if(sim.run.collected.has(key)) continue;
+      const p = pickupPos(i);
+      if(!p){ sim.run.collected.add(key); continue; }
+      if(Math.hypot(sim.run.x-p.x, sim.run.y-p.y) < PICKUP_R*1.5){
+        sim.run.collected.add(key);
+        if(p.type === 0){
+          // fuel canister: refill up to max
+          const before = sim.run.fuel ?? 0;
+          const maxFuel = sim.st.fuelMax ?? 0;
+          if(maxFuel > 0){
+            const gained = Math.min(maxFuel * 0.5, maxFuel - before);
+            sim.run.fuel = Math.min(maxFuel, before + maxFuel * 0.5);
+            popup(`⛽ FUEL +${gained.toFixed(1)}s`, 20);
+            SFX.ding();
+            burst(p.x, p.y, 14, '#4fc3f7', 7);
+          } else {
+            popup(`⛽ fuel canister (no rocket)`, 16);
+            SFX.tick();
+          }
         } else {
-          popup(`\u{1F4A5} -${dmg} · ${lm.name} ${Math.ceil(state.lmHP[lm.id]/lm.hp*100)}%`, 22);
-          SFX.thump();
-          cam.shake = Math.min(16, 8 + spNew*0.02);
-          burst(face, sim.run.y, 20, lm.color, 10);
-          sim.run.x = face - 1;
-          sim.run.vx = -Math.abs(sim.run.vx)*(0.25 + 0.05*Math.min(state.lvl.plating,4));
-          sim.run.tumble = Math.min(sim.run.tumble + 5, 8);
+          // speed boost: brief velocity kick in current direction
+          const sp = Math.hypot(sim.run.vx, sim.run.vy) || 1;
+          const kick = 22;
+          sim.run.vx += sim.run.vx/sp * kick;
+          sim.run.vy += sim.run.vy/sp * kick;
+          sim.run.boostT = (sim.run.boostT ?? 0) + 1.5; // signal to physics (read defensively)
+          popup(`\u{1F7E0} BOOST +${kick} m/s!`, 22);
+          SFX.ding();
+          cam.shake = Math.min(cam.shake+5, 14);
+          burst(p.x, p.y, 16, '#ff9800', 9);
         }
-        save();
-        break;
       }
     }
   }
+
+  /* ════════════════ landmarks ════════════════ */
+  // Physical bosses standing on the ice. Fly into one to damage it — the hurt
+  // persists between days — and bring it down for a payout. The Wall is the
+  // real victory condition.
+  //
+  // REWORK (P0): the old code reversed vx on every hit, so only one hit landed
+  // per flight even against a 12 000 HP wall. The new resolution:
+  //
+  //   • CONTINUOUS RAM: while the player is inside the landmark's x-band and
+  //     below its height, damage accumulates every physics step proportionally
+  //     to speed × smash × SMASH_DPS × dt. This way a fast, well-built pass
+  //     deals sustained damage through the entire width of the landmark. At
+  //     maxed rocket + plating (~120 m/s at Wall), a single 0.38 s traverse
+  //     deals ~6 600 dmg → the Wall falls in 2 passes, i.e. 1–2 skilled flights.
+  //
+  //   • PIERCE vs BOUNCE: if entry speed >= PIERCE_SPD the player punches
+  //     through (vx slows but stays positive). Below that the player bounces
+  //     back (gentler than the old hard reversal). The bounce still deals one
+  //     hit's worth of damage, just no sustained pass.
+  //
+  //   • POPUP THROTTLE: damage accrues silently every step, but a HP-percent
+  //     update popup fires once per 10 % HP lost so the screen stays readable.
+  //
+  //   • COMBO: entry into a living landmark feeds comboMult() once per pass,
+  //     applying to the final payout (not per-step — that would be exploitable).
+  //
+  //   • FEEDBACK: if the player is in the x-band but too high to hit, a
+  //     one-per-pass "too high, dive lower" popup fires. If the landmark is
+  //     already destroyed a "already rubble" cue fires once.
+  //
+  // SMASH_DPS: damage per second per (m/s of speed × smash stat).
+  // calibrated so: 120 m/s × 4.34 smash × SMASH_DPS × 0.38 s ≈ 6000 dmg
+  //   → SMASH_DPS = 6000 / (120 × 4.34 × 0.38) ≈ 30.3  → use 30.
+  const SMASH_DPS = 30;
+  // Speed threshold for pierce (forward ram) vs bounce.
+  const PIERCE_SPD = 50;
+  // Physics step size used for cooldown ticking (matches the fixed sim timestep).
+  const SIM_DT = 1/60;
+
+  function checkLandmarks(spNew){
+    // lmPassFired: transient set of string keys for once-per-pass popup guards
+    if(!sim.run.lmPassFired) sim.run.lmPassFired = new Set();
+    // lmInBandLast: which landmarks the player was inside on the previous step
+    if(!sim.run.lmInBand) sim.run.lmInBand = new Set();
+    // lmDmgAccum: fractional damage accumulator (float remainder before rounding)
+    if(!sim.run.lmDmgAccum) sim.run.lmDmgAccum = {};
+    // lmLastPct: last HP-percent at which we showed a damage popup (per landmark)
+    if(!sim.run.lmLastPct) sim.run.lmLastPct = {};
+    // lmEntryCombo: whether we've already fired comboMult() for this pass
+    if(!sim.run.lmEntryCombo) sim.run.lmEntryCombo = {};
+
+    let anyBandContact = false;
+
+    for(const lm of LANDMARKS){
+      const face = lm.x - lm.w*0.5;
+      const inBand = sim.run.vx > 0
+                  && sim.run.y < lm.h
+                  && sim.run.x >= face
+                  && sim.run.x <= lm.x + lm.w;
+
+      // ── exited band cleanup ──
+      if(!inBand){
+        if(sim.run.lmInBand.has(lm.id)){
+          sim.run.lmInBand.delete(lm.id);
+          // allow re-entry to retrigger popup guards (only clear rubble/over keys)
+          sim.run.lmPassFired.delete(lm.id + '_rubble');
+          sim.run.lmPassFired.delete(lm.id + '_over');
+          sim.run.lmEntryCombo[lm.id] = false;
+        }
+        // "flew over" check: in x-band but above the height cutoff
+        if(sim.run.vx > 0 && sim.run.x >= face && sim.run.x <= lm.x + lm.w
+           && sim.run.y >= lm.h && state.lmHP[lm.id] > 0){
+          const overKey = lm.id + '_over';
+          if(!sim.run.lmPassFired.has(overKey)){
+            sim.run.lmPassFired.add(overKey);
+            popup(`\u{2B06} Too high — dive below ${Math.round(lm.h)} m to hit ${lm.name}!`, 20);
+            SFX.blip(180, 0.08, 'sawtooth', 0.06);
+          }
+        } else if(sim.run.x > lm.x + lm.w){
+          sim.run.lmPassFired.delete(lm.id + '_over');
+        }
+        continue;
+      }
+
+      anyBandContact = true;
+      sim.run.lmInBand.add(lm.id);
+
+      // ── already destroyed ──
+      if(state.lmHP[lm.id] <= 0){
+        const rubbleKey = lm.id + '_rubble';
+        if(!sim.run.lmPassFired.has(rubbleKey)){
+          sim.run.lmPassFired.add(rubbleKey);
+          popup(`\u{1F4A8} ${lm.name} is already rubble!`, 18);
+          SFX.blip(300, 0.08, 'square', 0.05);
+        }
+        continue;
+      }
+
+      // ── entry vs sustain ──
+      const justEntered = !sim.run.lmEntryCombo[lm.id];
+      if(justEntered){
+        sim.run.lmEntryCombo[lm.id] = true;
+        if(spNew < PIERCE_SPD){
+          // BOUNCE: one sharp hit, reverse out
+          const dmg = Math.max(1, Math.round(spNew * sim.st.smash));
+          const prevHP = state.lmHP[lm.id];
+          state.lmHP[lm.id] = Math.max(0, prevHP - dmg);
+          comboMult(); // feeds combo but we don't use the multiplier on bounce cash
+          if(state.lmHP[lm.id] <= 0){
+            _landmarkDestroyed(lm, spNew);
+          } else {
+            const pct = Math.ceil(state.lmHP[lm.id]/lm.hp*100);
+            popup(`\u{1F4A5} -${dmg} · ${lm.name} ${pct}%`, 22);
+            SFX.thump();
+            cam.shake = Math.min(16, 8 + spNew*0.02);
+            burst(face + lm.w*0.5, sim.run.y, 16, lm.color, 8);
+            // bounce back (gentler than the old reversal)
+            sim.run.x = face - 1;
+            sim.run.vx = -Math.abs(sim.run.vx) * (0.18 + 0.04*Math.min(state.lvl.plating ?? 0, 4));
+            sim.run.tumble = Math.min(sim.run.tumble + 4, 8);
+            sim.run.lmLastPct[lm.id] = pct;
+            save();
+          }
+          break; // only one landmark per step
+        } else {
+          // PIERCE entry: shake + sound burst, damage will accumulate below
+          cam.shake = Math.min(16, 8 + spNew*0.03);
+          SFX.thump();
+          burst(face + lm.w*0.5, sim.run.y, 14, lm.color, 7);
+          sim.run.lmLastPct[lm.id] = sim.run.lmLastPct[lm.id]
+            ?? Math.ceil(state.lmHP[lm.id]/lm.hp*100);
+        }
+      }
+
+      if(spNew < PIERCE_SPD) break; // already handled in bounce branch above
+
+      // ── continuous pierce damage ──
+      // damage = spNew * smash * SMASH_DPS * dt, accumulated as float
+      const rawDmg = spNew * sim.st.smash * SMASH_DPS * SIM_DT;
+      sim.run.lmDmgAccum[lm.id] = (sim.run.lmDmgAccum[lm.id] ?? 0) + rawDmg;
+      const dmg = Math.floor(sim.run.lmDmgAccum[lm.id]);
+      if(dmg < 1){ break; } // accumulate until we have at least 1 HP to remove
+      sim.run.lmDmgAccum[lm.id] -= dmg;
+
+      const prevHP = state.lmHP[lm.id];
+      state.lmHP[lm.id] = Math.max(0, prevHP - dmg);
+
+      // ── speed bleed: fast pass costs some speed, slow pass costs more ──
+      // factor approaches 0 at very high speeds (light graze) → full bleed
+      // at barely-pierce speeds.
+      const bleedFactor = clamp(PIERCE_SPD / spNew, 0.1, 0.9);
+      sim.run.vx *= (1 - bleedFactor * 0.018);  // gentle per-step bleed
+      sim.run.tumble = Math.min(sim.run.tumble + 0.04, 6);
+
+      if(state.lmHP[lm.id] <= 0){
+        _landmarkDestroyed(lm, spNew);
+        break;
+      }
+
+      // throttle damage popups: show once per 10 % HP bracket crossed
+      const pct = Math.ceil(state.lmHP[lm.id]/lm.hp*100);
+      const lastPct = sim.run.lmLastPct[lm.id] ?? 100;
+      if(Math.floor(lastPct/10) > Math.floor(pct/10)){
+        const comboTag = sim.run.combo > 1 ? ` ×${sim.run.combo}` : '';
+        popup(`\u{1F4A5} ${lm.name} ${pct}%${comboTag}`, 20);
+        cam.shake = Math.min(cam.shake+3, 14);
+        sim.run.lmLastPct[lm.id] = pct;
+      }
+
+      save();
+      break; // one landmark per step
+    }
+  }
+
+  // Helper — fires the DESTROYED sequence (shared between bounce-kill and pierce-kill).
+  function _landmarkDestroyed(lm, spNew){
+    const m = comboMult();
+    const val = Math.round(lm.reward * m);
+    sim.run.smashCash += val;
+    popup(`\u{1F4A5} ${lm.name} DESTROYED! +${fmtCash(val)}${sim.run.combo>1?` ×${sim.run.combo}`:''}`, 30);
+    SFX.boom();
+    cam.shake = 16;
+    burst(lm.x, Math.min(sim.run.y+10, lm.h*0.6), 40, lm.color, 18);
+    // punch clean through — big speed loss but vx stays positive
+    sim.run.vx *= 0.5;
+    sim.run.vy *= 0.65;
+    save();
+  }
+
+  // No-op stub kept for forward compatibility if an orchestrator wires it.
+  function tickCooldowns(_dt){ /* cooldowns now handled inside checkLandmarks */ }
 
   return {
     coinCluster, comboMult, starPos, checkCollectibles,
     obstaclePos, checkObstacles, fireGun,
     ringPos, checkRings,
     checkLandmarks,
+    pickupPos, checkPickups, tickCooldowns,
     COIN_CELL, COIN_MIN_ALT, COIN_MAX_ALT, COIN_R,
     STAR_CELL, STAR_MIN_ALT, STAR_R,
     OBST_CELL, RING_CELL, RING_R,
+    PICKUP_CELL, PICKUP_R,
   };
 }

--- a/pages/flightless.html
+++ b/pages/flightless.html
@@ -40,6 +40,13 @@
     border:2px solid var(--yellow); padding:4px 10px;
     font-family:inherit; font-weight:bold; font-size:13px; cursor:pointer;
   }
+  #settings-btn{
+    position:absolute; top:10px; right:72px; z-index:30;
+    background:rgba(0,0,128,0.85); color:var(--yellow);
+    border:2px solid var(--yellow); padding:4px 10px;
+    font-family:inherit; font-weight:bold; font-size:13px; cursor:pointer;
+  }
+  #settings-btn:hover{ background:var(--yellow); color:var(--navy); }
 
   /* ── Flight HUD ── */
   #hud{
@@ -274,6 +281,28 @@
   #victory h1{ color:var(--yellow); text-shadow:3px 3px 0 var(--red); font-size:40px; letter-spacing:4px; }
   #victory p{ color:var(--text); font-size:15px; line-height:1.6; }
 
+  /* ── Settings panel ── */
+  #settings{ text-align:left; }
+  #settings .panel-inner{ max-width:460px; }
+  #settings h2{ color:var(--yellow); text-transform:uppercase; letter-spacing:3px; margin:0 0 18px; text-shadow:2px 2px 0 var(--red); }
+  .set-section{ background:var(--panel); border:2px solid var(--border); padding:14px 18px; margin-bottom:12px; }
+  .set-section h3{ margin:0 0 10px; color:var(--yellow); font-size:12px; text-transform:uppercase; letter-spacing:2px; }
+  .set-row{ display:flex; align-items:center; justify-content:space-between; padding:7px 0; border-bottom:1px dashed #2a2f70; gap:12px; }
+  .set-row:last-child{ border-bottom:none; }
+  .set-label{ font-size:13px; color:var(--text); }
+  .set-label small{ display:block; color:var(--muted); font-size:10.5px; margin-top:2px; }
+  .set-toggle{
+    font-family:inherit; font-size:12px; font-weight:bold; cursor:pointer;
+    background:var(--navy); color:var(--yellow);
+    border:2px solid var(--yellow); padding:4px 12px; min-width:64px; text-align:center;
+  }
+  .set-toggle:hover{ background:var(--yellow); color:var(--navy); }
+  .set-toggle.on{ background:var(--yellow); color:var(--navy); }
+  .set-slider{ -webkit-appearance:none; appearance:none; width:130px; height:8px; background:#20255e; border:1px solid var(--border); outline:none; cursor:pointer; }
+  .set-slider::-webkit-slider-thumb{ -webkit-appearance:none; appearance:none; width:16px; height:16px; background:var(--yellow); border:2px solid var(--navy); cursor:pointer; }
+  .set-slider::-moz-range-thumb{ width:14px; height:14px; background:var(--yellow); border:2px solid var(--navy); cursor:pointer; border-radius:0; }
+  #settings .big-btn{ margin:8px auto 0; padding:10px 40px; font-size:16px; }
+
   /* ── Touch controls ── */
   #touch{ position:absolute; bottom:0; left:0; right:0; z-index:15; display:none; justify-content:space-between; padding:0 14px 18px; pointer-events:none; }
   #touch .tbtn{
@@ -293,6 +322,7 @@
 <body>
 <canvas id="game"></canvas>
 <a class="overlay-link" href="/index.html">&larr; caleb's site</a>
+<button id="settings-btn" title="settings">&#9881;</button>
 <button id="mute-btn" title="toggle sound">&#128266;</button>
 
 <div id="hud">
@@ -418,17 +448,64 @@
 <!-- ── VICTORY ── -->
 <div class="panel" id="victory">
   <div class="panel-inner">
-    <h1>&#128039;&#128640; YOU LEARNED TO FLY</h1>
-    <p>35 kilometres out, there was a wall. There isn't any more.<br>
+    <h1 id="victory-title">&#128039;&#128640; YOU LEARNED TO FLY</h1>
+    <p id="victory-body">35 kilometres out, there was a wall. There isn't any more.<br>
     They said you were <i>flightless</i>. They can come look at the rubble.</p>
-    <p style="color:var(--muted);font-size:13px;">You can keep flying for fun &mdash; the sky was never the limit.</p>
-    <button class="big-btn" id="victory-btn">Keep Flying</button>
+    <p id="victory-sub" style="color:var(--muted);font-size:13px;">You can keep flying for fun &mdash; the sky was never the limit.</p>
+    <div style="display:flex;flex-wrap:wrap;gap:10px;justify-content:center;margin-top:18px;">
+      <button class="big-btn" id="victory-btn" style="margin:0;padding:10px 30px;font-size:17px;">Keep Flying</button>
+      <button class="big-btn" id="ng-plus-btn" style="margin:0;padding:10px 30px;font-size:17px;background:#000080;">&#128640; New Game+</button>
+    </div>
+    <p id="ng-hint" style="color:var(--muted);font-size:12px;margin-top:10px;text-align:center;"></p>
+  </div>
+</div>
+
+<!-- ── SETTINGS ── -->
+<div class="panel" id="settings">
+  <div class="panel-inner">
+    <h2>&#9881; Settings</h2>
+    <div class="set-section">
+      <h3>&#127925; Music</h3>
+      <div class="set-row">
+        <span class="set-label">Music
+          <small>background synth bed</small>
+        </span>
+        <button class="set-toggle" id="set-music-toggle">ON</button>
+      </div>
+      <div class="set-row">
+        <span class="set-label">Music volume</span>
+        <input type="range" class="set-slider" id="set-music-vol" min="0" max="1" step="0.05" value="1">
+      </div>
+    </div>
+    <div class="set-section">
+      <h3>&#128266; Sound FX</h3>
+      <div class="set-row">
+        <span class="set-label">SFX
+          <small>launch, collect, crash sounds</small>
+        </span>
+        <button class="set-toggle" id="set-sfx-toggle">ON</button>
+      </div>
+      <div class="set-row">
+        <span class="set-label">SFX volume</span>
+        <input type="range" class="set-slider" id="set-sfx-vol" min="0" max="1" step="0.05" value="1">
+      </div>
+    </div>
+    <div class="set-section">
+      <h3>&#9855; Accessibility</h3>
+      <div class="set-row">
+        <span class="set-label">Reduce motion
+          <small>damps camera shake &amp; particles</small>
+        </span>
+        <button class="set-toggle" id="set-reduce-motion">OFF</button>
+      </div>
+    </div>
+    <button class="big-btn" id="settings-close-btn">Done</button>
   </div>
 </div>
 
 <script type="module">
 import { createStore } from '../assets/js/flightless-store.js';
-import { defaultState, loadState, saveState } from '../assets/js/flightless-save.js';
+import { defaultState, loadState, saveState, exportSave, importSave } from '../assets/js/flightless-save.js';
 import { createSound } from '../assets/js/flightless-sound.js';
 import { createData } from '../assets/js/flightless-data.js';
 import { createPhysics } from '../assets/js/flightless-physics.js';
@@ -464,6 +541,7 @@ const sim = {
   phase: 'shop', run: null, ramp: null, st: null,
   particles: [], speedLines: [], timeSim: 0,
   W: 0, Hpx: 0, DPR: 1,
+  paused: false,  // reserved: set by hud-input; honored by the main loop
 };
 const cam = { x:0, y:0, z:6, shake:0 };
 const input = { up:false, down:false, boost:false, ff:false };
@@ -532,6 +610,7 @@ const physics = createPhysics({
   checkObstacles: world.checkObstacles,
   checkRings: world.checkRings,
   checkLandmarks: world.checkLandmarks,
+  checkPickups: world.checkPickups,
   popup: call('popup'), burst: call('burst'), onFinishRun: call('finishRun'),
 });
 bridge.derive = physics.derive;
@@ -549,6 +628,7 @@ const renderer = createRenderer({
   OBST_CELL: world.OBST_CELL, RING_CELL: world.RING_CELL, RING_R: world.RING_R,
   coinCluster: world.coinCluster, starPos: world.starPos,
   obstaclePos: world.obstaclePos, ringPos: world.ringPos,
+  pickupPos: world.pickupPos, PICKUP_CELL: world.PICKUP_CELL, PICKUP_R: world.PICKUP_R,
 });
 bridge.popup = renderer.popup;
 bridge.burst = renderer.burst;
@@ -571,6 +651,12 @@ const hudInput = createHudInput({
   fireGun: world.fireGun,
 });
 
+// Wire startMusic through bridge so it can be called after first user gesture.
+// Defensive: sound module may not expose startMusic yet.
+bridge.startMusic = typeof SFX.startMusic === 'function'
+  ? () => SFX.startMusic()
+  : () => {};
+
 /* ════════════════ shop UI ════════════════ */
 // The shop screen itself (tabs, upgrade/gear/bonus/medal shelves, ramp
 // designer) lives in its own module — see assets/js/flightless-store.js —
@@ -579,24 +665,70 @@ const introEl = document.getElementById('intro');
 const shopEl = document.getElementById('shop');
 const resultsEl = document.getElementById('results');
 const victoryEl = document.getElementById('victory');
+const settingsEl = document.getElementById('settings');
 
 function recompute(){ sim.st = physics.derive(); sim.ramp = physics.buildRamp(sim.st.rampLen); }
 
 const store = createStore({
   state, UPGRADES, GEAR, BONUS_SHOP, MEDALS, LANDMARKS, MILESTONES,
   contractsFor, upgCost, fmtCash, fmtDist, save, SFX, defaultState,
+  exportSave, importSave,
   getSt: () => sim.st, getRamp: () => sim.ramp, recompute,
   sampleShape: physics.sampleShape, clamp, RAD,
 });
 const renderShop = store.renderShop;
 
+/* ════════════════ NG+ — post-Wall endgame ════════════════ */
+// WIN_DIST is the base wall distance (35 000 m). Each NG+ cycle adds a
+// second, harder wall at 2× the original distance and scales enemy density.
+// state.ngPlus is seeded as 0 by save.js and read defensively throughout.
+
+function ngPlusWallDist(){
+  // NG+1 wall at 70 km, NG+2 at 105 km, etc.
+  const ng = state.ngPlus ?? 0;
+  return WIN_DIST * 2 * (ng + 1);
+}
+
+function openVictoryPanel(){
+  const ng = state.ngPlus ?? 0;
+  const nextWallKm = Math.round(ngPlusWallDist() / 1000);
+  const titleEl  = document.getElementById('victory-title');
+  const bodyEl   = document.getElementById('victory-body');
+  const subEl    = document.getElementById('victory-sub');
+  const hintEl   = document.getElementById('ng-hint');
+  const ngBtn    = document.getElementById('ng-plus-btn');
+
+  if(ng === 0){
+    // First win
+    titleEl.innerHTML  = '&#128039;&#128640; YOU LEARNED TO FLY';
+    bodyEl.innerHTML   = '35 kilometres out, there was a wall. There isn\'t any more.<br>They said you were <i>flightless</i>. They can come look at the rubble.';
+    subEl.textContent  = 'You can keep flying for fun — the sky was never the limit.';
+    hintEl.textContent = '★ New Game+ resets upgrades but keeps medals & bonus points — a harder wall awaits at '+nextWallKm+' km.';
+    ngBtn.textContent  = '\u{1F680} New Game+';
+  } else {
+    // Repeated NG+ wins
+    const nextKm = Math.round(ngPlusWallDist() / 1000);
+    titleEl.innerHTML  = '&#128039;&#128640; NG+'+ng+' COMPLETE';
+    bodyEl.innerHTML   = 'Another wall, another pile of rubble. The ice keeps going.<br>You\'re starting to think the sky has always been there for you.';
+    subEl.textContent  = 'Keep the streak alive — NG+'+(ng+1)+' awaits.';
+    hintEl.textContent = 'Next wall: '+nextKm+' km — upgrades reset, medals & BP carry on.';
+    ngBtn.textContent  = '\u{1F680} NG+'+(ng+1);
+  }
+
+  victoryEl.classList.add('show');
+  SFX.ding();
+}
+
 /* ════════════════ launch / shop / results flow ════════════════ */
 function closeResults(){
   resultsEl.classList.remove('show');
-  if(!state.won && state.lmHP.wall <= 0){
-    state.won = true; save();
-    victoryEl.classList.add('show');
-    SFX.ding();
+  if(state.lmHP.wall <= 0){
+    // Wall just fell (or was already down from a previous run landing here).
+    if(!state.won){
+      state.won = true;
+      save();
+    }
+    openVictoryPanel();
     return;
   }
   openShop();
@@ -612,11 +744,14 @@ function openShop(){
 
 function startLaunch(){
   SFX.ensure();
+  // Kick off background music on first user gesture (defensive: may not exist)
+  if(typeof SFX.startMusic === 'function') SFX.startMusic();
   if(!state.started){ state.started = true; save(); }
   introEl.classList.remove('show');
   shopEl.classList.remove('show');
   physics.newRun();
   sim.phase = 'ramp';
+  sim.paused = false;
   if(sim.st.sling > 0){
     renderer.popup(`\u{1F3AF} CATAPULT +${sim.st.sling} m/s!`, 24);
     SFX.boom();
@@ -634,13 +769,42 @@ function startLaunch(){
 document.getElementById('intro-launch-btn').addEventListener('click', startLaunch);
 document.getElementById('launch-btn').addEventListener('click', startLaunch);
 document.getElementById('continue-btn').addEventListener('click', closeResults);
+
+// Victory panel buttons
 document.getElementById('victory-btn').addEventListener('click', () => {
   victoryEl.classList.remove('show');
   openShop();
 });
+document.getElementById('ng-plus-btn').addEventListener('click', () => {
+  victoryEl.classList.remove('show');
+  // Increment NG+, reset upgrades/gear/progress, keep medals/BP/bonus/settings.
+  const ng = (state.ngPlus ?? 0) + 1;
+  const keep = {
+    muted: state.muted, musicMuted: state.musicMuted ?? false,
+    settings: state.settings ?? { reduceMotion:false, sfxVol:1, musicVol:1 },
+    medals: state.medals, bp: state.bp, bonus: state.bonus,
+    ngPlus: ng,
+  };
+  const fresh = defaultState();
+  for(const k of Object.keys(state)) delete state[k];
+  Object.assign(state, fresh, keep);
+  state.started = true;
+  state.won = false;
+  // Restore landmark HP to full for the new cycle (wall is already reset by defaultState)
+  // but scale enemy wall HP up per NG+ so the player faces a harder challenge.
+  const wallScale = 1 + ng * 0.5;   // NG+1 = 1.5×, NG+2 = 2×, etc.
+  state.lmHP.wall = Math.round(fresh.lmHP.wall * wallScale);
+  save();
+  openShop();
+});
+
 document.getElementById('reset-btn').addEventListener('click', () => {
   if(!confirm('Start over from Day 1? Medals, Bonus Points and Bonus Shop levels are permanent and carry over.')) return;
-  const keep = { muted:state.muted, medals:state.medals, bp:state.bp, bonus:state.bonus };
+  const keep = {
+    muted: state.muted, musicMuted: state.musicMuted ?? false,
+    settings: state.settings ?? { reduceMotion:false, sfxVol:1, musicVol:1 },
+    medals: state.medals, bp: state.bp, bonus: state.bonus,
+  };
   const fresh = defaultState();
   // mutate the existing object in place — every module holds a reference
   // to this same `state`, so reassigning the variable would leave them
@@ -652,10 +816,102 @@ document.getElementById('reset-btn').addEventListener('click', () => {
   openShop();
 });
 
+/* ════════════════ settings panel ════════════════ */
+function openSettings(){
+  // Sync controls to current state before showing.
+  const musicMuted = state.musicMuted ?? false;
+  const settings   = state.settings   ?? { reduceMotion:false, sfxVol:1, musicVol:1 };
+  const sfxMuted   = state.muted;
+
+  const musicToggle  = document.getElementById('set-music-toggle');
+  const musicVol     = document.getElementById('set-music-vol');
+  const sfxToggle    = document.getElementById('set-sfx-toggle');
+  const sfxVol       = document.getElementById('set-sfx-vol');
+  const reduceMotion = document.getElementById('set-reduce-motion');
+
+  musicToggle.textContent  = musicMuted ? 'OFF' : 'ON';
+  musicToggle.classList.toggle('on', !musicMuted);
+  musicVol.value           = settings.musicVol ?? 1;
+  sfxToggle.textContent    = sfxMuted ? 'OFF' : 'ON';
+  sfxToggle.classList.toggle('on', !sfxMuted);
+  sfxVol.value             = settings.sfxVol ?? 1;
+  reduceMotion.textContent = (settings.reduceMotion ?? false) ? 'ON' : 'OFF';
+  reduceMotion.classList.toggle('on', settings.reduceMotion ?? false);
+
+  settingsEl.classList.add('show');
+}
+
+function closeSettings(){
+  settingsEl.classList.remove('show');
+}
+
+document.getElementById('settings-btn').addEventListener('click', openSettings);
+document.getElementById('settings-close-btn').addEventListener('click', closeSettings);
+
+// Music mute toggle
+document.getElementById('set-music-toggle').addEventListener('click', () => {
+  state.musicMuted = !(state.musicMuted ?? false);
+  save();
+  const el = document.getElementById('set-music-toggle');
+  el.textContent = state.musicMuted ? 'OFF' : 'ON';
+  el.classList.toggle('on', !state.musicMuted);
+  // Inform the sound module if it supports music (defensive)
+  if(typeof SFX.setMusicVolume === 'function'){
+    SFX.setMusicVolume(state.musicMuted ? 0 : (state.settings?.musicVol ?? 1));
+  }
+  if(!state.musicMuted && typeof SFX.startMusic === 'function') SFX.startMusic();
+});
+
+// Music volume slider
+document.getElementById('set-music-vol').addEventListener('input', e => {
+  if(!state.settings) state.settings = { reduceMotion:false, sfxVol:1, musicVol:1 };
+  state.settings.musicVol = parseFloat(e.target.value);
+  save();
+  if(typeof SFX.setMusicVolume === 'function' && !(state.musicMuted ?? false)){
+    SFX.setMusicVolume(state.settings.musicVol);
+  }
+});
+
+// SFX mute toggle
+document.getElementById('set-sfx-toggle').addEventListener('click', () => {
+  state.muted = !state.muted;
+  save();
+  renderMute();   // keep the corner mute button in sync
+  const el = document.getElementById('set-sfx-toggle');
+  el.textContent = state.muted ? 'OFF' : 'ON';
+  el.classList.toggle('on', !state.muted);
+  if(state.muted) SFX.setThrust(false);
+});
+
+// SFX volume slider
+document.getElementById('set-sfx-vol').addEventListener('input', e => {
+  if(!state.settings) state.settings = { reduceMotion:false, sfxVol:1, musicVol:1 };
+  state.settings.sfxVol = parseFloat(e.target.value);
+  save();
+  // Defensive: sound module may expose setSfxVolume in a future revision
+  if(typeof SFX.setSfxVolume === 'function') SFX.setSfxVolume(state.settings.sfxVol);
+});
+
+// Reduce-motion toggle
+document.getElementById('set-reduce-motion').addEventListener('click', () => {
+  if(!state.settings) state.settings = { reduceMotion:false, sfxVol:1, musicVol:1 };
+  state.settings.reduceMotion = !(state.settings.reduceMotion ?? false);
+  save();
+  const el = document.getElementById('set-reduce-motion');
+  el.textContent = state.settings.reduceMotion ? 'ON' : 'OFF';
+  el.classList.toggle('on', state.settings.reduceMotion);
+});
+
 /* ════════════════ main loop ════════════════ */
 // Fixed 240 Hz timestep with an accumulator: every physics step is the same
 // size no matter the frame rate or phase, so the ramp→flight transition costs
 // exactly the same as any other step and the integration is deterministic.
+//
+// Pause behavior (sim.paused — set by hud-input):
+//   When paused during 'ramp' or 'flight', the accumulator is NOT advanced and
+//   physics steps are skipped entirely, so no sim state is mutated. The
+//   renderer still fires every rAF so the player sees the frozen frame.
+//   lastT is kept current so no banked time sneaks in on resume.
 const FIXED_DT = 1/240;
 let lastT = performance.now(), simAcc = 0, hudT = 0;
 function loop(now){
@@ -664,33 +920,43 @@ function loop(now){
   lastT = now;
   sim.timeSim += dtReal;
 
-  // time scale: player fast-forward, plus auto-FF for slide-outs and long ramp rides
-  let scale = 1;
-  if(sim.phase==='flight' && sim.run){
-    scale = input.ff ? 3 : (sim.run.sliding ? 2.5 : 2.4);
-  } else if(sim.phase==='ramp' && sim.ramp){
-    scale = clamp(1.8 + sim.ramp.len/150, 1.8, 3.2);
-  }
-  const dt = dtReal*scale;
+  // Honor pause: skip physics + accumulator when paused mid-flight/ramp.
+  // Still render so the frozen frame stays on screen.
+  const isActive = sim.phase==='ramp' || sim.phase==='flight';
+  const frozen   = isActive && (sim.paused ?? false);
 
-  if(sim.phase==='ramp' || sim.phase==='flight'){
-    simAcc = Math.min(simAcc + dt, 0.15);
-    while(simAcc >= FIXED_DT){
-      if(sim.phase==='ramp') physics.stepRamp(FIXED_DT);
-      else if(sim.run && !sim.run.done) physics.stepFlight(FIXED_DT);
-      else break;
-      simAcc -= FIXED_DT;
-      if(sim.phase==='results'){ simAcc = 0; break; }
+  if(!frozen){
+    // time scale: player fast-forward, plus auto-FF for slide-outs and long ramp rides
+    let scale = 1;
+    if(sim.phase==='flight' && sim.run){
+      scale = input.ff ? 3 : (sim.run.sliding ? 2.5 : 2.4);
+    } else if(sim.phase==='ramp' && sim.ramp){
+      scale = clamp(1.8 + sim.ramp.len/150, 1.8, 3.2);
     }
-  } else simAcc = 0;
+    const dt = dtReal*scale;
 
-  renderer.stepParticles(dt);
-  renderer.stepSpeedLines(dt);
+    if(isActive){
+      simAcc = Math.min(simAcc + dt, 0.15);
+      while(simAcc >= FIXED_DT){
+        if(sim.phase==='ramp') physics.stepRamp(FIXED_DT);
+        else if(sim.run && !sim.run.done) physics.stepFlight(FIXED_DT);
+        else break;
+        simAcc -= FIXED_DT;
+        if(sim.phase==='results'){ simAcc = 0; break; }
+      }
+    } else simAcc = 0;
+
+    renderer.stepParticles(dt);
+    renderer.stepSpeedLines(dt);
+  }
+  // Always draw — paused state shows a frozen frame; renderer reads sim.paused
+  // to optionally overlay a "PAUSED" indicator if it chooses.
   renderer.draw(dtReal);
-  if((sim.phase==='ramp'||sim.phase==='flight') && sim.run){
+
+  if(isActive && sim.run && !frozen){
     hudT -= dtReal;
     if(hudT <= 0){ hudInput.renderHUD(); hudT = 0.08; }   // ~12 Hz is plenty for text
-  } else hudT = 0;
+  } else if(!isActive) hudT = 0;
 }
 
 // boot: first-ever visit goes straight to the ramp, no shop


### PR DESCRIPTION
Rewrote FLIGHTLESS_ROADMAP.md with corrected P0 diagnoses, a shared- invariants contract for parallel work, and per-component charters. Then improved every module:

- world:   P0 landmark rework — continuous pierce damage so a fast pass
           deals sustained damage (Wall falls in 1-2 flights, not 6);
           "dive lower"/"already rubble" feedback; combo unification;
           fuel/boost pickups
- data:    milestone respread + upgrade cost-curve pass (no more one-flight
           max-out); landmark HP/reward tuning; +medals/contracts; daily
           modifier/deal tables; rocket preview now reads derive()
- save:    schema versioning + migration chain; export/import; hardened
           allowlist sanitization; forward-looking default fields; lmHP
           defaults realigned to data.js
- physics: overheat + coast-on-fumes; diminishing thrust returns;
           defensive daily-wind hook; new run tracking fields
- render:  speed/afterburner FX; day/night cycle; landmark debris; ramp
           variety; reduced-motion; weather particles; pickup drawing
- sound:   engine hum, impact variety, flap/cheer/oof, looping music with
           independent mute
- store:   ramp presets; multi-level stat projections; bonus respec; save
           export/import UI (applies imported state in place)
- hud:     pause (sim.paused); touch/keyboard-aware hints; drag-to-steer +
           haptics; onboarding call-outs
- results: 25 headline variants; sponsor-patience meter; bark cues
- html:    honors sim.paused; New Game+/second-wall endgame; settings
           panel; wires pickups (physics+render) and save import/export