### PR TITLE
Redesign upgrade tree as radial grid with achievements panel

### DIFF
--- a/assets/js/flightless-data.js
+++ b/assets/js/flightless-data.js
@@ -21,31 +21,34 @@ export function createData({ state, derive, buildRamp, rampExitEst, gliderName, 
   // incrementing state.lvl[id], so every other consumer (physics/hud/
   // results) that already reads state.perm.speedo etc. needs no changes.
   //
-  // This is a real tree. `requires` is an array of upgrade ids that must
-  // each be at level ≥1 (or owned, for oneTime nodes) before a card is even
-  // buyable — some nodes need one prerequisite, some need two — and every
-  // base cost is high enough relative to early/mid earnings that getting
-  // even one upgrade should take multiple flights of saving, not one.
-  // Tree shape:
+  // This is a real branching tree with a single root — the Ramp, dead
+  // centre. Everything grows outward from it in all directions. `requires`
+  // is an array of prerequisite entries, each either:
+  //   'id'            — that upgrade must be at level ≥1 (owned, for oneTime)
+  //   { id, lvl }     — that upgrade must be at level ≥ lvl
+  // The level form lets a branch hang off a *specific rung* of its parent —
+  // the Speedometer isn't worth reading until you've a few Ramp levels of
+  // speed to read, so it needs Ramp Lv.3; Fuel Regen only pays off once
+  // you've a deep Fuel Tank and real glider time, so it needs Fuel Lv.4 AND
+  // Glider Wings Lv.3. Base costs stay high enough that even one upgrade is
+  // several flights of saving.
+  // Tree shape (▲ up = flight, ▼ down = ground game, ◀ left = instruments,
+  // ▶ right = economy — all radiating from ramp):
   //
-  //   ramp, speedo, wings, cargo   (roots — no prerequisites; ramp is the
-  //                                 cheapest, the obvious first buy)
-  //     ├─ alti      (speedo)
-  //     ├─ aero      (wings)
-  //     ├─ bounce    (ramp)
-  //     ├─ struts    (wings + aero)
-  //     ├─ sling     (ramp + bounce)
-  //     ├─ rocket    (wings + aero)
-  //     │   ├─ fuel     (rocket)
-  //     │   │   ├─ regen    (fuel + sponsor)
-  //     │   │   │   └─ tank     (fuel + regen)
-  //     │   │   └─ burner   (rocket)
-  //     │   └─ plating  (struts + rocket)
-  //     │       └─ gun      (rocket + plating)
-  //     └─ sponsor   (aero + bounce)
+  //   ramp  (root — centre, cheapest, the obvious first buy)
+  //     ◀ speedo   (ramp Lv.3) ─ alti (speedo)
+  //     ▶ cargo    (ramp)
+  //     ▼ bounce   (ramp Lv.2) ─ sling (bounce)
+  //     ▼ sponsor  (bounce)
+  //     ▲ wings    (ramp Lv.2)
+  //         ▲ aero (wings)
+  //             ▲ struts (aero) ─ plating (struts) ─ gun (plating)
+  //             ▲ rocket (aero) ─ burner (rocket)
+  //                 ▲ fuel (rocket)
+  //                     ▲ regen (fuel Lv.4 + wings Lv.3) ─ tank (regen)
   //
   // Distance-based `unlock` gates stay as a secondary check (mostly already
-  // trivial next to the new prerequisite gate) — the real gate is now cost
+  // trivial next to the prerequisite gate) — the real gate is now cost
   // + tree position.
   //
   // Daily delivery cap: how many $ purchases (upgrades + gear; the BP-funded
@@ -64,14 +67,14 @@ export function createData({ state, derive, buildRamp, rampExitEst, gliderName, 
       desc:'More track to build speed on. Reshape it in the designer below.',
       val:l=>{ const d=derive({ramp:l}); const r=buildRamp(d.rampLen);
                return `${Math.round(d.rampLen)} m · ${Math.round(r.H)} m tall · ~${Math.round(rampExitEst(d, r))} m/s exit`; } },
-    { id:'speedo', icon:'\u{1F4DF}', name:'Speedometer', base:65, mul:1, max:1, unlock:0, requires:[], oneTime:true,
+    { id:'speedo', icon:'\u{1F4DF}', name:'Speedometer', base:65, mul:1, max:1, unlock:0, requires:[{id:'ramp',lvl:3}], oneTime:true,
       desc:'See your speed — and get paid for top speed.',
       val:l=> l===0 ? 'not installed' : 'installed' },
-    { id:'wings',   icon:'\u{1FABD}', name:'Glider Wings', base:90, mul:1.55, max:10, unlock:0, requires:[],
+    { id:'wings',   icon:'\u{1FABD}', name:'Glider Wings', base:90, mul:1.55, max:10, unlock:0, requires:[{id:'ramp',lvl:2}],
       desc:'More lift, flatter glide. Ease off "up" to cruise. New rig every couple of levels.',
       val:l=>{ if(l===0) return 'no wings'; const d=derive({wings:l});
                return `${gliderName(l)} · ~${Math.max(1,Math.round(d.bestLD))}:1 glide`; } },
-    { id:'cargo', icon:'\u{1F4E6}', name:'Cargo Crate', base:150, mul:1.6, max:7, unlock:0, requires:[],
+    { id:'cargo', icon:'\u{1F4E6}', name:'Cargo Crate', base:150, mul:1.6, max:7, unlock:0, requires:['ramp'],
       desc:'How many upgrades Fish Co. can drop off before your next flight. Bigger crate, more buys per visit.',
       val:l=>`${DAILY_CAP_BASE+l} deliveries/day` },
 
@@ -82,24 +85,24 @@ export function createData({ state, derive, buildRamp, rampExitEst, gliderName, 
     { id:'aero',    icon:'\u{1F9CA}', name:'Slick Suit',   base:70,  mul:1.55, max:10, unlock:0, requires:['wings'],
       desc:'Waxed feathers cut drag on the ramp, in the air, and on the ice.',
       val:l=>`dives to ~${Math.round(derive({aero:l}).vDive)} m/s` },
-    { id:'bounce',  icon:'\u{1F3C0}', name:'Rubber Belly', base:450, mul:1.55, max:6, unlock:0, requires:['ramp'],
+    { id:'bounce',  icon:'\u{1F3C0}', name:'Rubber Belly', base:450, mul:1.55, max:6, unlock:0, requires:[{id:'ramp',lvl:2}],
       desc:'Spring back on landing. Keep momentum for distance.',
       val:l=> l===0 ? 'splat' : `${Math.round((0.12+0.09*l)*100)}% bounce` },
 
     // ── tier 2 (two prerequisites) ──
-    { id:'struts',  icon:'\u{1F529}', name:'Wing Struts',  base:500, mul:1.55, max:6, unlock:250, requires:['wings','aero'],
+    { id:'struts',  icon:'\u{1F529}', name:'Wing Struts',  base:500, mul:1.55, max:6, unlock:250, requires:['aero'],
       desc:'Stiffer spars pull harder turns at speed without folding.',
       val:l=>`${derive({struts:l}).gMax.toFixed(1)}g max pull` },
-    { id:'sling',   icon:'\u{1F3AF}', name:'Catapult',     base:1100, mul:1.55, max:8, unlock:500, requires:['ramp','bounce'],
+    { id:'sling',   icon:'\u{1F3AF}', name:'Catapult',     base:1100, mul:1.55, max:8, unlock:500, requires:['bounce'],
       desc:'An elastic winch flings you from the gate at the top of the track.',
       val:l=> l===0 ? 'not installed' : `+${20*l} m/s at the gate` },
 
     // Rocket: mul raised 1.55→1.65 to slow the runaway late-game power spike.
-    { id:'rocket',  icon:'\u{1F680}', name:'Rocket',       base:380, mul:1.65, max:10, unlock:100, requires:['wings','aero'],
+    { id:'rocket',  icon:'\u{1F680}', name:'Rocket',       base:380, mul:1.65, max:10, unlock:100, requires:['aero'],
       desc:'A strap-on booster. Hold SPACE to climb faster.',
       val:l=> l===0 ? 'not installed' : `${Math.round(derive({rocket:l}).thrust)} m/s² thrust` },
     // Sponsor: multiplier stacks hard with airtime — keep it a real reach.
-    { id:'sponsor', icon:'\u{1F4B0}', name:'Sponsor Deal', base:850, mul:1.60, max:6, unlock:250, requires:['aero','bounce'],
+    { id:'sponsor', icon:'\u{1F4B0}', name:'Sponsor Deal', base:850, mul:1.60, max:6, unlock:250, requires:['bounce'],
       desc:'Fish Co. multiplies your earnings on every flight.',
       val:l=>`×${(1+0.35*l).toFixed(2)} cash earned` },
 
@@ -110,14 +113,14 @@ export function createData({ state, derive, buildRamp, rampExitEst, gliderName, 
     { id:'burner', icon:'\u{1F4A5}', name:'Afterburner', base:2800, mul:1, max:1, unlock:1000, requires:['rocket'], oneTime:true,
       desc:'Once per flight, press X: instant +90 m/s. No fuel.',
       val:l=> l===0 ? 'not installed' : 'installed' },
-    { id:'plating', icon:'\u{1F6E1}', name:'Ram Plating',  base:1000, mul:1.55, max:6, unlock:1500, requires:['struts','rocket'],
+    { id:'plating', icon:'\u{1F6E1}', name:'Ram Plating',  base:1000, mul:1.55, max:6, unlock:1500, requires:['struts'],
       desc:'An armored belly plate. Smash landmarks harder and keep more speed on impact.',
       val:l=>`×${(1+0.35*l).toFixed(2)} smash damage`,
     },
 
     // ── tier 4 (deepest nodes) ──
     // Gun: a true late-game luxury, now gated behind rocket + plating too.
-    { id:'gun',     icon:'\u{1F52B}', name:'Sky Cannon',   base:6000, mul:1.75, max:6, unlock:2500, requires:['rocket','plating'],
+    { id:'gun',     icon:'\u{1F52B}', name:'Sky Cannon',   base:6000, mul:1.75, max:6, unlock:2500, requires:['plating'],
       desc:'Press C to blast obstacles out of the sky. Upgrade for range and bigger targets.',
       val:l=>{ if(l===0) return 'not installed';
                const tier = l>=5?'planes':l>=3?'balloons':'birds';
@@ -125,12 +128,12 @@ export function createData({ state, derive, buildRamp, rampExitEst, gliderName, 
     // Fuel Regen: mid-late-game payoff for rocket-heavy builds — passively
     // refills the tank while gliding (not thrusting). See physics.js's
     // regenRate stat and the "cool down" branch of stepFlight.
-    { id:'regen',   icon:'\u{267B}\u{FE0F}', name:'Fuel Regen',  base:900, mul:1.6, max:5, unlock:1000, requires:['fuel','sponsor'],
+    { id:'regen',   icon:'\u{267B}\u{FE0F}', name:'Fuel Regen',  base:900, mul:1.6, max:5, unlock:1000, requires:[{id:'fuel',lvl:4},{id:'wings',lvl:3}],
       desc:'Slowly refills the tank while gliding — coast to keep the rocket fed.',
       val:l=> l===0 ? 'no regen' : `${(0.12*l).toFixed(2)} s of burn / s gliding` },
 
     // ── tier 5 (deepest) ──
-    { id:'tank',   icon:'\u{1F6E2}', name:'Reserve Tank', base:6500, mul:1, max:1, unlock:2500, requires:['fuel','regen'], oneTime:true,
+    { id:'tank',   icon:'\u{1F6E2}', name:'Reserve Tank', base:6500, mul:1, max:1, unlock:2500, requires:['regen'], oneTime:true,
       desc:'Rocket refuels to half on your first ground bounce.',
       val:l=> l===0 ? 'not installed' : 'installed' },
   ];

--- a/assets/js/flightless-save.js
+++ b/assets/js/flightless-save.js
@@ -53,7 +53,9 @@ export function defaultState(){
     everDid: {},
     // ramp spline control points in unit shape space (gate → lip); the last
     // point IS the lip. Upgrades buy track length; this is the shape of it.
-    rampShape: [{x:0.03,y:0.95},{x:0.16,y:0.32},{x:0.72,y:0.02},{x:1,y:0.10}],
+    // Default shape: gate at the top-left, dropping to the ice, then curving
+    // back up to about a third height by the lip on the right.
+    rampShape: [{x:0.03,y:0.97},{x:0.30,y:0.05},{x:0.65,y:0.18},{x:1,y:0.33}],
   };
 }
 

--- a/assets/js/flightless-store.js
+++ b/assets/js/flightless-store.js
@@ -174,38 +174,39 @@ export function createStore(deps){
   };
 
   // ── tree layout ──
-  // Every upgrade gets its own dedicated row (lane) — never shared with
-  // another upgrade — because each of its LEVELS is its own individual
-  // grid cell/node, laid out one per column along that lane: level i of
-  // an upgrade sits at column `startCol+i`. That's what makes it read as
-  // a path (a chain of level-nodes strung left→right) rather than a
-  // cluster. `startCol` is 1 + the deepest prerequisite's own startCol
-  // (so a path only ever begins strictly right of every upgrade whose
-  // level-1 node unlocks it — matching the actual gate, which only needs
-  // level ≥ 1, not a maxed prerequisite), i.e. the same tiers the old
-  // upgDepth() scheme used. Rows are ordered so branches fan both above
-  // and below the wings/aero/rocket hub, not in one flat stack — that's
-  // the "all four directions" part; the horizontal path itself always
-  // runs left→right, and only the connector between a prerequisite's
-  // first node and its dependent's first node bends up or down.
+  // One node per upgrade, hand-placed on a grid with the Ramp dead centre
+  // and every branch radiating outward from it — up is the flight tech
+  // spine (wings → aero → {struts→plating→gun, rocket→{burner, fuel→regen→
+  // tank}}), down is the ground game (bounce→sling, sponsor), left is the
+  // instrument branch (speedo→alti), right is the economy branch (cargo).
+  // These are pure presentation; the real gates are `requires`/`unlock` in
+  // flightless-data.js. Coordinates were chosen so a prerequisite always
+  // sits adjacent to (or at least inward of) its dependents, so the SVG
+  // connector lines read as a tree rather than a hairball. A node missing
+  // from this table falls back to the centre cell rather than crashing.
+  const CENTER = { col:3, row:7 };
   const TREE_LAYOUT = {
-    speedo:  { col:1, row:1 },
-    alti:    { col:2, row:2 },
-    ramp:    { col:1, row:3 },
-    bounce:  { col:2, row:4 },
-    sling:   { col:3, row:5 },
-    sponsor: { col:3, row:6 },
-    wings:   { col:1, row:7 },
-    aero:    { col:2, row:8 },
-    struts:  { col:3, row:9 },
-    rocket:  { col:3, row:10 },
-    fuel:    { col:4, row:11 },
-    regen:   { col:5, row:12 },
-    tank:    { col:6, row:13 },
-    burner:  { col:4, row:14 },
-    plating: { col:4, row:15 },
-    gun:     { col:5, row:16 },
-    cargo:   { col:1, row:17 },
+    ramp:    { col:3, row:7 },   // ── centre / root ──
+    // ◀ instruments
+    speedo:  { col:2, row:7 },
+    alti:    { col:1, row:7 },
+    // ▶ economy
+    cargo:   { col:4, row:7 },
+    // ▼ ground game
+    bounce:  { col:3, row:8 },
+    sling:   { col:3, row:9 },
+    sponsor: { col:4, row:8 },
+    // ▲ flight spine
+    wings:   { col:3, row:6 },
+    aero:    { col:3, row:5 },
+    struts:  { col:2, row:4 },
+    rocket:  { col:4, row:4 },
+    plating: { col:1, row:3 },
+    gun:     { col:1, row:2 },
+    burner:  { col:4, row:3 },
+    fuel:    { col:5, row:3 },
+    regen:   { col:6, row:2 },
+    tank:    { col:6, row:1 },
   };
 
   // Connector redraw hook — renderShop() swaps in a closure over the
@@ -217,6 +218,25 @@ export function createStore(deps){
   window.addEventListener('resize', () => redrawConnectors && redrawConnectors());
   if(typeof ResizeObserver === 'function'){
     new ResizeObserver(() => redrawConnectors && redrawConnectors()).observe(shopGrid);
+  }
+
+  // Center the scroll viewport on the Ramp (the tree's root) the first time
+  // the shop is laid out — the tree is bigger than the viewport and radiates
+  // from the middle, so the player should open onto the centre and pan out,
+  // not onto the top of the flight branch. Once done we leave scroll alone
+  // so buying (which re-renders but never moves a node) doesn't yank the
+  // view around.
+  const shopScroll = document.querySelector('#shop .shop-scroll');
+  let didCenterTree = false;
+  function centerOnRoot(rootEl){
+    if(didCenterTree || !rootEl || !shopScroll) return;
+    const sr = shopScroll.getBoundingClientRect();
+    if(sr.height < 2) return;                 // still hidden — try again later
+    const rr = rootEl.getBoundingClientRect();
+    shopScroll.scrollTop  += (rr.top  + rr.height/2) - (sr.top  + sr.height/2);
+    const gr = shopGrid.getBoundingClientRect();
+    shopGrid.scrollLeft   += (rr.left + rr.width/2)  - (gr.left + gr.width/2);
+    didCenterTree = true;
   }
 
   // ── ramp designer (collapsible pop-over) ──
@@ -515,179 +535,184 @@ export function createStore(deps){
     })() : null;
     // todaysDeal is expected to be { id, discount } — e.g. { id: 'engine', discount: 0.25 }
 
-    // upgrade tree — unlocked at distance milestones AND tree prerequisites.
-    // A maxed-out node drops off the list entirely (its slot is free for a
-    // later tier), and a locked one (missing a prerequisite) doesn't show
-    // at all — no "requires X + Y" clutter for nodes you can't work toward
-    // yet. Everything whose prerequisites ARE met stays visible regardless
-    // of affordability — a real tree has real branches, hiding options
-    // behind "only show the cheapest" fights against letting the player see
-    // and choose between them. `oneTime` nodes (formerly the separate GEAR
-    // list — Speedometer, Altimeter, Afterburner, Reserve Tank) are bought
-    // once ever: ownership lives in state.perm[id] instead of state.lvl[id],
-    // so physics/hud/results (which already read state.perm.speedo etc.)
-    // needed no changes.
+    // ── upgrade tree ──
+    // A bog-standard branching upgrade tree: one node per upgrade, the Ramp
+    // dead centre, every branch radiating outward (see TREE_LAYOUT). EVERY
+    // node is always on screen — a locked one (prerequisites not yet met)
+    // renders greyed with a lock so the player can see the whole tree and
+    // plan a route outward; a maxed one stays put showing ✓ MAX. Each node
+    // shows its icon, the price of its NEXT level underneath, and a row of
+    // pips for level progress; the name, current effect and any unmet
+    // requirement only ever appear in the hover tooltip. `oneTime` nodes
+    // (Speedometer, Altimeter, Afterburner, Reserve Tank) are bought once
+    // ever — ownership lives in state.perm[id], everything else in
+    // state.lvl[id].
     //
-    // Layout: a real 2-D tree on TREE_LAYOUT's grid — every node sits at
-    // its hand-placed (col, row), branching above and below its roots as
-    // well as left-to-right by tier, with an SVG underlay drawing a
-    // connector from each visible prerequisite node to its dependent (a
-    // two-parent node gets two lines in). Each node itself is still the
-    // flat row of per-level icons: only the level right after the owned
-    // count is buyable, later levels show their price greyed out, and
-    // name/per-level effect/price only ever show in the hover tooltip.
-    shopGrid.innerHTML = '';
-    function isOwned(id){
+    // `requires` entries are either 'id' (needs level ≥1 / owned) or
+    // { id, lvl } (needs level ≥ lvl) — see flightless-data.js. reqId/
+    // reqLvl/reqMet normalise both forms.
+    const reqId  = r => typeof r === 'string' ? r : r.id;
+    const reqLvl = r => typeof r === 'string' ? 1 : (r.lvl || 1);
+    function levelOf(id){
       const u = UPGRADES.find(x => x.id === id);
-      if(!u) return false;
-      return u.oneTime ? !!state.perm[id] : (state.lvl[id] ?? 0) > 0;
+      if(!u) return 0;
+      return u.oneTime ? (state.perm[id] ? 1 : 0) : (state.lvl[id] ?? 0);
     }
+    const reqMet = r => levelOf(reqId(r)) >= reqLvl(r);
     function ownedLevel(u){ return u.oneTime ? (state.perm[u.id] ? 1 : 0) : (state.lvl[u.id] ?? 0); }
-    const missingRequires = u => (u.requires || []).filter(id => !isOwned(id));
-    const upgAvail = UPGRADES.filter(u =>
-      state.best.dist >= (u.unlock||0) && ownedLevel(u) < u.max && missingRequires(u).length === 0);
+    const upgById = Object.fromEntries(UPGRADES.map(u => [u.id, u]));
     const capOut = capRemaining() <= 0;
 
+    shopGrid.innerHTML = '';
     const svgNS = 'http://www.w3.org/2000/svg';
     const treeSvg = document.createElementNS(svgNS, 'svg');
     treeSvg.setAttribute('class', 'tree-svg');
     treeSvg.setAttribute('preserveAspectRatio', 'none');
     shopGrid.appendChild(treeSvg);
 
-    // firstNodeEls: upgrade id → its level-1 cell (the branch point other
-    // upgrades' prerequisite lines connect to, and where its own path
-    // starts). lastNodeEls: upgrade id → its furthest-right rendered cell
-    // (where the path's own rail line ends). nodeAffordable: upgrade id →
-    // true if its next buyable level is affordable right now (colors both
-    // the rail and any dependent's incoming connector gold).
-    const firstNodeEls = {};
-    const lastNodeEls = {};
-    const nodeAffordable = {};
+    const nodeEls = {};          // id → node element (for connector geometry)
+    const nodeState = {};        // id → 'locked' | 'buyable' | 'maxed'
 
-    for(const u of upgAvail){
+    for(const u of UPGRADES){
+      const pos = TREE_LAYOUT[u.id] || CENTER;
       const lvl = ownedLevel(u);
-      const levels = u.oneTime ? 1 : u.max;
-      const pos = TREE_LAYOUT[u.id] || { col:1, row:1 };
-      let lastCell = null;
+      const max = u.oneTime ? 1 : u.max;
+      const maxed = lvl >= max;
 
-      for(let i=0; i<levels; i++){
-        const owned = i < lvl;
-        const isNext = i === lvl;
-        const rawCost = u.oneTime ? u.base : Math.round(u.base * Math.pow(u.mul, i));
+      const unmet = (u.requires || []).filter(r => !reqMet(r));
+      const distLocked = state.best.dist < (u.unlock || 0);
+      const locked = unmet.length > 0 || distLocked;
 
-        // Daily deal discount only ever applies to the next buyable level.
-        const isDailyDeal = isNext && todaysDeal && todaysDeal.id === u.id;
-        const dealDiscount = isDailyDeal && typeof todaysDeal.discount === 'number'
-          ? clamp(todaysDeal.discount, 0, 0.9) : 0;
-        const cost = isDailyDeal ? Math.max(1, Math.round(rawCost * (1 - dealDiscount))) : rawCost;
-        const affordable = isNext && !capOut && state.money >= cost;
-        if(affordable) nodeAffordable[u.id] = true;
+      // next-level pricing (+ daily deal, only when actually buyable)
+      const rawCost = u.oneTime ? u.base : Math.round(u.base * Math.pow(u.mul, lvl));
+      const isDailyDeal = !locked && !maxed && todaysDeal && todaysDeal.id === u.id;
+      const dealDiscount = isDailyDeal && typeof todaysDeal.discount === 'number'
+        ? clamp(todaysDeal.discount, 0, 0.9) : 0;
+      const cost = isDailyDeal ? Math.max(1, Math.round(rawCost * (1 - dealDiscount))) : rawCost;
+      const affordable = !locked && !maxed && !capOut && state.money >= cost;
 
-        const cell = document.createElement('div');
-        cell.className = 'lvl-icon' +
-          (owned ? ' owned' : isNext ? ' next' : ' locked') +
-          (affordable ? ' affordable' : '') + (isDailyDeal ? ' daily-deal' : '');
-        cell.style.gridColumn = pos.col + i;
-        cell.style.gridRow = pos.row;
+      const status = maxed ? 'maxed' : locked ? 'locked' : 'buyable';
+      nodeState[u.id] = status;
 
-        const effect = u.oneTime ? u.desc : u.val(i + 1);
-        const statusLine = owned ? 'owned'
-          : isNext && capOut ? 'no deliveries left today'
-          : isDailyDeal ? `${fmtCash(cost)} (deal, was ${fmtCash(rawCost)})`
-          : fmtCash(cost);
-        const tipLabel = levels > 1 ? `${u.name} · Lv.${i+1}` : u.name;
+      const node = document.createElement('div');
+      node.className = 'upg-node ' + status +
+        (affordable ? ' affordable' : '') + (isDailyDeal ? ' daily-deal' : '');
+      node.style.gridColumn = pos.col;
+      node.style.gridRow = pos.row;
 
-        cell.innerHTML = `
-          <div class="lvl-art">${UPG_ICONS[u.id] || `<span style="font-size:28px">${u.icon}</span>`}</div>
-          <div class="lvl-price">${owned ? '✓' : fmtCash(cost)}</div>
-          <div class="lvl-tip"><b>${tipLabel}</b>${effect}<br>${statusLine}</div>`;
+      // pips: one per level, filled up to current level
+      const pips = Array.from({length:max}, (_,i) =>
+        `<span class="pip${i < lvl ? ' on' : ''}"></span>`).join('');
 
-        if(isNext){
-          cell.tabIndex = 0;
-          cell.addEventListener('click', () => {
-            if(state.money < cost || capRemaining() <= 0) return;
-            state.money -= cost;
-            if(u.oneTime) state.perm[u.id] = true;
-            else state.lvl[u.id]++;
-            registerPurchase();
-            econLog?.logBuy({ name: u.name, id: u.id, cost, lvl: u.oneTime ? 'owned' : state.lvl[u.id] });
-            SFX.buy();
-            save();
-            renderShop();
-            recompute();   // live-preview taller ramp behind the shop
-          });
-        }
-        shopGrid.appendChild(cell);
-        if(i === 0) firstNodeEls[u.id] = cell;
-        lastCell = cell;
+      // price line under the icon
+      const priceHTML = maxed ? '<span class="pmax">✓ MAX</span>'
+        : locked ? '<span class="plock">🔒</span>'
+        : isDailyDeal
+          ? `<span class="pdeal">${fmtCash(cost)}</span> <s>${fmtCash(rawCost)}</s>`
+          : `<span class="pnow">${fmtCash(cost)}</span>`;
+
+      // hover tooltip — name, current/next effect, and any unmet requirement
+      const effect = u.oneTime ? u.desc
+        : maxed ? u.val(lvl) : u.val(lvl + 1);
+      const reqNote = unmet.length
+        ? `<span class="need">Needs ${unmet.map(r => {
+            const ru = upgById[reqId(r)];
+            const nm = ru ? ru.name : reqId(r);
+            return reqLvl(r) > 1 ? `${nm} Lv.${reqLvl(r)}` : nm;
+          }).join(' + ')}</span>`
+        : distLocked ? `<span class="need">Reach ${fmtDist(u.unlock)} first</span>` : '';
+      const lvlNote = maxed ? 'maxed' : `Lv.${lvl}/${max}`;
+      const tipStatus = maxed ? '' : locked ? '' : `<div class="tip-buy">Buy Lv.${lvl+1} — ${fmtCash(cost)}${isDailyDeal ? ' ⚡deal' : ''}</div>`;
+
+      node.innerHTML = `
+        <div class="node-art">${UPG_ICONS[u.id] || `<span style="font-size:30px">${u.icon}</span>`}</div>
+        <div class="node-price">${priceHTML}</div>
+        <div class="node-pips">${pips}</div>
+        <div class="node-tip">
+          <b>${u.name}</b>
+          <span class="tip-lvl">${lvlNote}</span>
+          <span class="tip-effect">${effect}</span>
+          ${reqNote}${tipStatus}
+        </div>`;
+
+      if(status === 'buyable'){
+        node.tabIndex = 0;
+        const buy = () => {
+          if(locked || maxed) return;
+          if(state.money < cost || capRemaining() <= 0) return;
+          state.money -= cost;
+          if(u.oneTime) state.perm[u.id] = true;
+          else state.lvl[u.id]++;
+          registerPurchase();
+          econLog?.logBuy({ name: u.name, id: u.id, cost, lvl: u.oneTime ? 'owned' : state.lvl[u.id] });
+          SFX.buy();
+          save();
+          renderShop();
+          recompute();   // live-preview taller ramp behind the shop
+        };
+        node.addEventListener('click', buy);
+        node.addEventListener('keydown', e => { if(e.key === 'Enter' || e.key === ' '){ e.preventDefault(); buy(); } });
       }
-      lastNodeEls[u.id] = lastCell;
+
+      shopGrid.appendChild(node);
+      nodeEls[u.id] = node;
     }
 
     // ── connector pass ──
-    // Two kinds of line, both drawn from real DOM rects so they're correct
-    // regardless of how far a lane wanders up or down:
-    //  1. a path rail — a plain line strung through every level-node of one
-    //     upgrade, first to last, so its levels read as one chain rather
-    //     than loose dots;
-    //  2. a prerequisite branch — a bezier from a prerequisite's level-1
-    //     node (the actual unlock point: `requires` only ever needs level
-    //     ≥ 1) to its dependent's level-1 node. A prerequisite that's
-    //     maxed out and no longer rendered simply contributes no line.
-    // Either kind glows dusk-gold when the destination upgrade's next level
-    // is affordable right now; otherwise it stays glacial blue.
+    // One bezier per prerequisite edge, from the parent node's centre to
+    // the dependent's centre, drawn from real DOM rects so it's correct in
+    // any direction the branch happens to run. An edge whose requirement is
+    // already satisfied is drawn solid (the path you've walked / can walk);
+    // an edge into a still-locked node is drawn dim + dashed (a route not
+    // yet open). A level-threshold edge (e.g. regen needs wings Lv.3) is
+    // labelled with the level at its midpoint so cross-branch gates read.
     function drawConnectors(){
       while(treeSvg.firstChild) treeSvg.removeChild(treeSvg.firstChild);
       const g = shopGrid.getBoundingClientRect();
       if(g.width < 2 || g.height < 2) return;   // shop hidden — retry on observe
       treeSvg.setAttribute('viewBox', `0 0 ${g.width} ${g.height}`);
 
-      function line(x1, y1, x2, y2, gold, dashed){
-        const path = document.createElementNS(svgNS, 'path');
-        path.setAttribute('d', `M ${x1} ${y1} L ${x2} ${y2}`);
-        path.setAttribute('fill', 'none');
-        path.setAttribute('stroke', gold ? 'rgba(255,200,87,0.55)' : 'rgba(148,164,224,0.35)');
-        path.setAttribute('stroke-width', dashed ? '3' : '2');
-        if(dashed) path.setAttribute('stroke-linecap', 'round');
-        treeSvg.appendChild(path);
-      }
-      function curve(x1, y1, x2, y2, gold){
-        const bend = Math.max(16, (x2 - x1) * 0.5);
-        const path = document.createElementNS(svgNS, 'path');
-        path.setAttribute('d', `M ${x1} ${y1} C ${x1+bend} ${y1}, ${x2-bend} ${y2}, ${x2} ${y2}`);
-        path.setAttribute('fill', 'none');
-        path.setAttribute('stroke', gold ? 'rgba(255,200,87,0.6)' : 'rgba(148,164,224,0.45)');
-        path.setAttribute('stroke-width', '2');
-        treeSvg.appendChild(path);
-        for(const [cx, cy] of [[x1, y1], [x2, y2]]){
-          const dot = document.createElementNS(svgNS, 'circle');
-          dot.setAttribute('cx', cx); dot.setAttribute('cy', cy);
-          dot.setAttribute('r', '2.6');
-          dot.setAttribute('fill', gold ? 'rgba(255,200,87,0.85)' : 'rgba(148,164,224,0.65)');
-          treeSvg.appendChild(dot);
-        }
-      }
+      const cx = el => el.getBoundingClientRect().left + el.getBoundingClientRect().width/2 - g.left;
+      const cy = el => el.getBoundingClientRect().top + el.getBoundingClientRect().height/2 - g.top;
 
-      for(const u of upgAvail){
-        const gold = !!nodeAffordable[u.id];
-        // 1. this upgrade's own path rail (skip single-level upgrades)
-        const first = firstNodeEls[u.id], last = lastNodeEls[u.id];
-        if(first && last && first !== last){
-          const fr = first.getBoundingClientRect(), lr = last.getBoundingClientRect();
-          line(fr.left + fr.width/2 - g.left, fr.top + fr.height/2 - g.top,
-               lr.left + lr.width/2 - g.left, lr.top + lr.height/2 - g.top, gold, true);
-        }
-        // 2. branch curves in from every visible prerequisite
-        for(const rid of (u.requires || [])){
-          const parent = firstNodeEls[rid];
-          const node = firstNodeEls[u.id];
-          if(!parent || !node) continue;
-          const nr = node.getBoundingClientRect();
-          const pr = parent.getBoundingClientRect();
-          curve(pr.right - g.left, pr.top + pr.height/2 - g.top,
-                nr.left - g.left, nr.top + nr.height/2 - g.top, gold);
+      for(const u of UPGRADES){
+        const node = nodeEls[u.id];
+        if(!node) continue;
+        for(const r of (u.requires || [])){
+          const parent = nodeEls[reqId(r)];
+          if(!parent) continue;
+          const met = reqMet(r);
+          const x1 = cx(parent), y1 = cy(parent), x2 = cx(node), y2 = cy(node);
+          // bend along the dominant axis so vertical & horizontal edges both curve gently
+          const horiz = Math.abs(x2 - x1) >= Math.abs(y2 - y1);
+          const bx = horiz ? Math.max(14, Math.abs(x2 - x1) * 0.4) : 0;
+          const by = horiz ? 0 : Math.max(14, Math.abs(y2 - y1) * 0.4);
+          const c1x = x1 + (horiz ? (x2>x1?bx:-bx) : 0), c1y = y1 + (horiz ? 0 : (y2>y1?by:-by));
+          const c2x = x2 - (horiz ? (x2>x1?bx:-bx) : 0), c2y = y2 - (horiz ? 0 : (y2>y1?by:-by));
+          const path = document.createElementNS(svgNS, 'path');
+          path.setAttribute('d', `M ${x1} ${y1} C ${c1x} ${c1y}, ${c2x} ${c2y}, ${x2} ${y2}`);
+          path.setAttribute('fill', 'none');
+          path.setAttribute('stroke', met ? 'rgba(255,200,87,0.5)' : 'rgba(120,134,190,0.35)');
+          path.setAttribute('stroke-width', met ? '2.4' : '2');
+          if(!met) path.setAttribute('stroke-dasharray', '5 5');
+          path.setAttribute('stroke-linecap', 'round');
+          treeSvg.appendChild(path);
+          // level-threshold badge at the edge midpoint
+          if(reqLvl(r) > 1){
+            const mx = (x1 + x2)/2, my = (y1 + y2)/2;
+            const badge = document.createElementNS(svgNS, 'text');
+            badge.setAttribute('x', mx); badge.setAttribute('y', my);
+            badge.setAttribute('text-anchor', 'middle');
+            badge.setAttribute('dominant-baseline', 'central');
+            badge.setAttribute('font-size', '9');
+            badge.setAttribute('font-weight', '700');
+            badge.setAttribute('fill', met ? 'rgba(255,216,138,0.95)' : 'rgba(160,172,214,0.8)');
+            badge.textContent = 'L' + reqLvl(r);
+            treeSvg.appendChild(badge);
+          }
         }
       }
+      centerOnRoot(nodeEls['ramp']);
     }
     redrawConnectors = drawConnectors;
     requestAnimationFrame(drawConnectors);

--- a/assets/js/flightless-store.js
+++ b/assets/js/flightless-store.js
@@ -173,6 +173,52 @@ export function createStore(deps){
       `<line x1="33" y1="32" x2="33" y2="38" stroke="${IC.G}" stroke-width="2.2"/>`),
   };
 
+  // ── tree layout ──
+  // Every upgrade gets its own dedicated row (lane) — never shared with
+  // another upgrade — because each of its LEVELS is its own individual
+  // grid cell/node, laid out one per column along that lane: level i of
+  // an upgrade sits at column `startCol+i`. That's what makes it read as
+  // a path (a chain of level-nodes strung left→right) rather than a
+  // cluster. `startCol` is 1 + the deepest prerequisite's own startCol
+  // (so a path only ever begins strictly right of every upgrade whose
+  // level-1 node unlocks it — matching the actual gate, which only needs
+  // level ≥ 1, not a maxed prerequisite), i.e. the same tiers the old
+  // upgDepth() scheme used. Rows are ordered so branches fan both above
+  // and below the wings/aero/rocket hub, not in one flat stack — that's
+  // the "all four directions" part; the horizontal path itself always
+  // runs left→right, and only the connector between a prerequisite's
+  // first node and its dependent's first node bends up or down.
+  const TREE_LAYOUT = {
+    speedo:  { col:1, row:1 },
+    alti:    { col:2, row:2 },
+    ramp:    { col:1, row:3 },
+    bounce:  { col:2, row:4 },
+    sling:   { col:3, row:5 },
+    sponsor: { col:3, row:6 },
+    wings:   { col:1, row:7 },
+    aero:    { col:2, row:8 },
+    struts:  { col:3, row:9 },
+    rocket:  { col:3, row:10 },
+    fuel:    { col:4, row:11 },
+    regen:   { col:5, row:12 },
+    tank:    { col:6, row:13 },
+    burner:  { col:4, row:14 },
+    plating: { col:4, row:15 },
+    gun:     { col:5, row:16 },
+    cargo:   { col:1, row:17 },
+  };
+
+  // Connector redraw hook — renderShop() swaps in a closure over the
+  // current node set. renderShop() runs while #shop is still display:none
+  // (the host page adds .show right after), so rects are all zero at build
+  // time; the ResizeObserver fires when the grid actually gets laid out
+  // (0 → real size), and again on any wrap/resize.
+  let redrawConnectors = null;
+  window.addEventListener('resize', () => redrawConnectors && redrawConnectors());
+  if(typeof ResizeObserver === 'function'){
+    new ResizeObserver(() => redrawConnectors && redrawConnectors()).observe(shopGrid);
+  }
+
   // ── ramp designer (collapsible pop-over) ──
   // A one-line summary button in the shop footer; the canvas appears above
   // it on demand. All four control points drag, including the lip, so the
@@ -482,12 +528,14 @@ export function createStore(deps){
     // so physics/hud/results (which already read state.perm.speedo etc.)
     // needed no changes.
     //
-    // Layout: one flat grid, one icon cell per level of each visible
-    // upgrade, grouped so an upgrade's levels sit contiguously (in
-    // UPGRADES' own root→leaf order — no depth tiers, no connector lines).
-    // Only the level right after the owned count is buyable; later levels
-    // show their price greyed out so the player can plan ahead. Name,
-    // per-level effect, and price only ever show in the hover tooltip.
+    // Layout: a real 2-D tree on TREE_LAYOUT's grid — every node sits at
+    // its hand-placed (col, row), branching above and below its roots as
+    // well as left-to-right by tier, with an SVG underlay drawing a
+    // connector from each visible prerequisite node to its dependent (a
+    // two-parent node gets two lines in). Each node itself is still the
+    // flat row of per-level icons: only the level right after the owned
+    // count is buyable, later levels show their price greyed out, and
+    // name/per-level effect/price only ever show in the hover tooltip.
     shopGrid.innerHTML = '';
     function isOwned(id){
       const u = UPGRADES.find(x => x.id === id);
@@ -500,11 +548,27 @@ export function createStore(deps){
       state.best.dist >= (u.unlock||0) && ownedLevel(u) < u.max && missingRequires(u).length === 0);
     const capOut = capRemaining() <= 0;
 
+    const svgNS = 'http://www.w3.org/2000/svg';
+    const treeSvg = document.createElementNS(svgNS, 'svg');
+    treeSvg.setAttribute('class', 'tree-svg');
+    treeSvg.setAttribute('preserveAspectRatio', 'none');
+    shopGrid.appendChild(treeSvg);
+
+    // firstNodeEls: upgrade id → its level-1 cell (the branch point other
+    // upgrades' prerequisite lines connect to, and where its own path
+    // starts). lastNodeEls: upgrade id → its furthest-right rendered cell
+    // (where the path's own rail line ends). nodeAffordable: upgrade id →
+    // true if its next buyable level is affordable right now (colors both
+    // the rail and any dependent's incoming connector gold).
+    const firstNodeEls = {};
+    const lastNodeEls = {};
+    const nodeAffordable = {};
+
     for(const u of upgAvail){
       const lvl = ownedLevel(u);
       const levels = u.oneTime ? 1 : u.max;
-      const group = document.createElement('div');
-      group.className = 'upg-group';
+      const pos = TREE_LAYOUT[u.id] || { col:1, row:1 };
+      let lastCell = null;
 
       for(let i=0; i<levels; i++){
         const owned = i < lvl;
@@ -517,11 +581,14 @@ export function createStore(deps){
           ? clamp(todaysDeal.discount, 0, 0.9) : 0;
         const cost = isDailyDeal ? Math.max(1, Math.round(rawCost * (1 - dealDiscount))) : rawCost;
         const affordable = isNext && !capOut && state.money >= cost;
+        if(affordable) nodeAffordable[u.id] = true;
 
         const cell = document.createElement('div');
         cell.className = 'lvl-icon' +
           (owned ? ' owned' : isNext ? ' next' : ' locked') +
           (affordable ? ' affordable' : '') + (isDailyDeal ? ' daily-deal' : '');
+        cell.style.gridColumn = pos.col + i;
+        cell.style.gridRow = pos.row;
 
         const effect = u.oneTime ? u.desc : u.val(i + 1);
         const statusLine = owned ? 'owned'
@@ -550,10 +617,80 @@ export function createStore(deps){
             recompute();   // live-preview taller ramp behind the shop
           });
         }
-        group.appendChild(cell);
+        shopGrid.appendChild(cell);
+        if(i === 0) firstNodeEls[u.id] = cell;
+        lastCell = cell;
       }
-      shopGrid.appendChild(group);
+      lastNodeEls[u.id] = lastCell;
     }
+
+    // ── connector pass ──
+    // Two kinds of line, both drawn from real DOM rects so they're correct
+    // regardless of how far a lane wanders up or down:
+    //  1. a path rail — a plain line strung through every level-node of one
+    //     upgrade, first to last, so its levels read as one chain rather
+    //     than loose dots;
+    //  2. a prerequisite branch — a bezier from a prerequisite's level-1
+    //     node (the actual unlock point: `requires` only ever needs level
+    //     ≥ 1) to its dependent's level-1 node. A prerequisite that's
+    //     maxed out and no longer rendered simply contributes no line.
+    // Either kind glows dusk-gold when the destination upgrade's next level
+    // is affordable right now; otherwise it stays glacial blue.
+    function drawConnectors(){
+      while(treeSvg.firstChild) treeSvg.removeChild(treeSvg.firstChild);
+      const g = shopGrid.getBoundingClientRect();
+      if(g.width < 2 || g.height < 2) return;   // shop hidden — retry on observe
+      treeSvg.setAttribute('viewBox', `0 0 ${g.width} ${g.height}`);
+
+      function line(x1, y1, x2, y2, gold, dashed){
+        const path = document.createElementNS(svgNS, 'path');
+        path.setAttribute('d', `M ${x1} ${y1} L ${x2} ${y2}`);
+        path.setAttribute('fill', 'none');
+        path.setAttribute('stroke', gold ? 'rgba(255,200,87,0.55)' : 'rgba(148,164,224,0.35)');
+        path.setAttribute('stroke-width', dashed ? '3' : '2');
+        if(dashed) path.setAttribute('stroke-linecap', 'round');
+        treeSvg.appendChild(path);
+      }
+      function curve(x1, y1, x2, y2, gold){
+        const bend = Math.max(16, (x2 - x1) * 0.5);
+        const path = document.createElementNS(svgNS, 'path');
+        path.setAttribute('d', `M ${x1} ${y1} C ${x1+bend} ${y1}, ${x2-bend} ${y2}, ${x2} ${y2}`);
+        path.setAttribute('fill', 'none');
+        path.setAttribute('stroke', gold ? 'rgba(255,200,87,0.6)' : 'rgba(148,164,224,0.45)');
+        path.setAttribute('stroke-width', '2');
+        treeSvg.appendChild(path);
+        for(const [cx, cy] of [[x1, y1], [x2, y2]]){
+          const dot = document.createElementNS(svgNS, 'circle');
+          dot.setAttribute('cx', cx); dot.setAttribute('cy', cy);
+          dot.setAttribute('r', '2.6');
+          dot.setAttribute('fill', gold ? 'rgba(255,200,87,0.85)' : 'rgba(148,164,224,0.65)');
+          treeSvg.appendChild(dot);
+        }
+      }
+
+      for(const u of upgAvail){
+        const gold = !!nodeAffordable[u.id];
+        // 1. this upgrade's own path rail (skip single-level upgrades)
+        const first = firstNodeEls[u.id], last = lastNodeEls[u.id];
+        if(first && last && first !== last){
+          const fr = first.getBoundingClientRect(), lr = last.getBoundingClientRect();
+          line(fr.left + fr.width/2 - g.left, fr.top + fr.height/2 - g.top,
+               lr.left + lr.width/2 - g.left, lr.top + lr.height/2 - g.top, gold, true);
+        }
+        // 2. branch curves in from every visible prerequisite
+        for(const rid of (u.requires || [])){
+          const parent = firstNodeEls[rid];
+          const node = firstNodeEls[u.id];
+          if(!parent || !node) continue;
+          const nr = node.getBoundingClientRect();
+          const pr = parent.getBoundingClientRect();
+          curve(pr.right - g.left, pr.top + pr.height/2 - g.top,
+                nr.left - g.left, nr.top + nr.height/2 - g.top, gold);
+        }
+      }
+    }
+    redrawConnectors = drawConnectors;
+    requestAnimationFrame(drawConnectors);
   }
 
   return { renderShop, drawEditor };

--- a/assets/js/flightless-store.js
+++ b/assets/js/flightless-store.js
@@ -2,8 +2,9 @@
 //
 // Owns everything about the in-between-flights shop screen: the single
 // unified upgrade tree (upgrades + one-time gear, all one grid now — no
-// more tabs), the goals list (milestones + daily contracts + landmarks +
-// the medal wall), and the ramp-shape designer pop-over. It has no physics
+// more tabs), the achievements grid (milestones + daily contracts +
+// landmarks + medals, all one icon grid — no text goals list), and the
+// ramp-shape designer pop-over. It has no physics
 // or rendering of its own — it's handed the save state, the upgrade/medal
 // data tables, and a handful of pure helper functions from the host page,
 // and it owns the DOM inside #shop from there.
@@ -14,7 +15,7 @@
 export function createStore(deps){
   const {
     state, UPGRADES, MEDALS, LANDMARKS, MILESTONES,
-    contractsFor, upgCost, fmtCash, fmtDist, save, SFX, defaultState,
+    contractsFor, fmtCash, fmtDist, save, SFX, defaultState,
     getSt, getRamp, recompute, sampleShape, clamp, RAD, econLog,
   } = deps;
   const DAILY_CAP_BASE = typeof deps.DAILY_CAP_BASE === 'number' ? deps.DAILY_CAP_BASE : 3;
@@ -53,8 +54,7 @@ export function createStore(deps){
   }
 
   const shopGrid = document.getElementById('shop-grid');
-  const medalRow = document.getElementById('medal-row');
-  const goalList = document.getElementById('goal-list');
+  const achGrid = document.getElementById('ach-grid');
 
   // ── upgrade icons (inline SVG, Arctic Dusk palette) ──
   // Purely presentational, so they live here in the store module rather
@@ -173,29 +173,6 @@ export function createStore(deps){
       `<line x1="33" y1="32" x2="33" y2="38" stroke="${IC.G}" stroke-width="2.2"/>`),
   };
 
-  // ── tree depth ──
-  // Tier = longest prerequisite chain below a node, computed over the FULL
-  // upgrade table (not just visible cards) so a node never jumps rows as
-  // parents max out and drop off the grid.
-  const upgById = Object.fromEntries(UPGRADES.map(u => [u.id, u]));
-  const depthMemo = {};
-  function upgDepth(id){
-    if(id in depthMemo) return depthMemo[id];
-    const req = upgById[id]?.requires || [];
-    return depthMemo[id] = req.length ? 1 + Math.max(...req.map(upgDepth)) : 0;
-  }
-
-  // Connector redraw hook — renderShop() swaps in a closure over the
-  // current card set. renderShop() runs while #shop is still display:none
-  // (the host page adds .show right after), so rects are all zero at build
-  // time; the ResizeObserver fires when the grid actually gets laid out
-  // (0 → real size), and again on any wrap/resize.
-  let redrawConnectors = null;
-  window.addEventListener('resize', () => redrawConnectors && redrawConnectors());
-  if(typeof ResizeObserver === 'function'){
-    new ResizeObserver(() => redrawConnectors && redrawConnectors()).observe(shopGrid);
-  }
-
   // ── ramp designer (collapsible pop-over) ──
   // A one-line summary button in the shop footer; the canvas appears above
   // it on demand. All four control points drag, including the lip, so the
@@ -210,75 +187,6 @@ export function createStore(deps){
   const edX = p => ED_PAD + p.x*(ED_W-2*ED_PAD);
   const edY = p => ED_GROUND - p.y*(ED_GROUND-ED_TOP);
   let edDrag = -1;
-
-  // ── ramp designer presets ──
-  // Preset control-point arrays: each entry is a full rampShape replacement.
-  // Points are in normalised [0,1]×[0,1] coordinates matching the editor's
-  // convention: x increases left→right along the ramp base, y=0 is ground
-  // level and y=1 is the top of the editor canvas.
-  const RAMP_PRESETS = [
-    {
-      label: '🚀 Steep Launch',
-      // Gate high, kicker near the end, lip shoots near-vertical.
-      shape: [
-        { x: 0.08, y: 0.82 },
-        { x: 0.38, y: 0.65 },
-        { x: 0.68, y: 0.38 },
-        { x: 0.92, y: 0.14 },
-      ],
-    },
-    {
-      label: '🪂 Long Glide',
-      // Gentle ramp for maximum horizontal carry rather than altitude.
-      shape: [
-        { x: 0.06, y: 0.55 },
-        { x: 0.32, y: 0.42 },
-        { x: 0.62, y: 0.28 },
-        { x: 0.94, y: 0.18 },
-      ],
-    },
-    {
-      label: '🛹 Trick Ramp',
-      // Mid-height kicker with a sharp upswing at the lip for combos/style.
-      shape: [
-        { x: 0.07, y: 0.45 },
-        { x: 0.28, y: 0.35 },
-        { x: 0.60, y: 0.50 },
-        { x: 0.90, y: 0.22 },
-      ],
-    },
-  ];
-
-  // Build the preset button row and append it into #ramp-pop (above the
-  // canvas) so the DOM order is: presets → canvas → footer.
-  const presetRow = document.createElement('div');
-  presetRow.style.cssText = 'display:flex;gap:4px;justify-content:center;flex-wrap:wrap;margin-bottom:2px;';
-  for(const preset of RAMP_PRESETS){
-    const btn = document.createElement('button');
-    btn.textContent = preset.label;
-    btn.style.cssText = [
-      'font-family:inherit',
-      'font-size:10px',
-      'cursor:pointer',
-      'background:var(--panel)',
-      'color:var(--text)',
-      'border:1px solid var(--border)',
-      'padding:3px 7px',
-      'border-radius:3px',
-    ].join(';');
-    btn.addEventListener('mouseenter', () => { btn.style.borderColor = 'var(--yellow)'; });
-    btn.addEventListener('mouseleave', () => { btn.style.borderColor = 'var(--border)'; });
-    btn.addEventListener('click', () => {
-      // Deep-copy the preset so later drags don't mutate our constant.
-      state.rampShape = preset.shape.map(p => ({ ...p }));
-      recompute();
-      save();
-      drawEditor();
-    });
-    presetRow.appendChild(btn);
-  }
-  // Insert before the canvas (first child of ramp-pop).
-  rampPop.insertBefore(presetRow, rampPop.firstChild);
 
   function drawEditor(){
     const ramp = getRamp();
@@ -508,47 +416,51 @@ export function createStore(deps){
       controlsHintEl.textContent = segs.join(' · ');
     }
 
-    // goals
-    goalList.innerHTML = '';
+    // achievements — milestones, landmark bosses, daily contracts, and
+    // medals all render as one flat icon grid: no text list, ever. Each
+    // badge is on/off (plus a transitional next/partial/contract state);
+    // name, reward, and progress detail live in the hover tooltip only.
+    achGrid.innerHTML = '';
+    function addBadge(icon, title, cls, pct){
+      const b = document.createElement('div');
+      b.className = 'ach ' + cls;
+      b.title = title;
+      b.textContent = icon;
+      if(pct != null){
+        const p = document.createElement('span');
+        p.className = 'ach-pct';
+        p.textContent = pct + '%';
+        b.appendChild(p);
+      }
+      achGrid.appendChild(b);
+    }
+    // distance milestones — the next unclaimed one gets a "next" highlight
     let nextMarked = false;
     for(const [dist, cash] of MILESTONES){
-      const li = document.createElement('li');
       const done = state.claimed.includes(dist);
-      li.textContent = `${fmtDist(dist)} (${fmtCash(cash)})`;
-      if(done) li.className = 'done';
-      else if(!nextMarked){ li.className = 'next'; li.textContent = '▶ '+li.textContent; nextMarked = true; }
-      goalList.appendChild(li);
+      let cls = done ? 'on' : 'off';
+      let title = `${fmtDist(dist)} — ${fmtCash(cash)}${done ? ' (claimed)' : ''}`;
+      if(!done && !nextMarked){ cls = 'next'; title = '▶ Next: ' + title; nextMarked = true; }
+      addBadge('\u{1F6A9}', title, cls);
     }
-    // today's contracts
+    // today's contracts — previewed, not tracked (judged at flight's end)
     for(const c of contractsFor(state.day)){
-      const li = document.createElement('li');
-      li.textContent = `\u{1F4CB} ${c.text} (+${fmtCash(c.reward)})`;
-      li.style.color = 'var(--text)';
-      goalList.appendChild(li);
+      addBadge('\u{1F4CB}', `${c.text} — +${fmtCash(c.reward)}`, 'contract');
     }
-    // landmark status
+    // landmark bosses — pct shown is damage dealt so far, 0–100%
     for(const lm of LANDMARKS){
       const hp = state.lmHP[lm.id];
-      const li = document.createElement('li');
-      if(hp <= 0){
-        li.textContent = `\u{1F4A5} ${lm.name} destroyed`;
-        li.className = 'done';
-      } else {
-        li.textContent = `\u{1F3AF} ${lm.name} @ ${fmtDist(lm.x)} — ${Math.ceil(hp/lm.hp*100)}%`;
-      }
-      goalList.appendChild(li);
+      const down = hp <= 0;
+      const dmgPct = Math.min(100, Math.max(0, 100 - Math.ceil(hp/lm.hp*100)));
+      addBadge('\u{1F3AF}',
+        down ? `${lm.name} — destroyed (+${fmtCash(lm.reward)})` : `${lm.name} @ ${fmtDist(lm.x)} — ${dmgPct}% damaged`,
+        down ? 'on' : (dmgPct > 0 ? 'partial' : 'off'),
+        down || dmgPct === 0 ? null : dmgPct);
     }
-
-    // medal wall — unified into Goals (no separate tab): earned bright,
-    // unearned greyed, cash value (if any) shown in the tooltip
-    medalRow.innerHTML = '';
+    // permanent medals — earned bright, unearned greyed
     for(const m of MEDALS){
       const got = state.medals.includes(m.id);
-      const chip = document.createElement('div');
-      chip.className = 'medal ' + (got ? 'on' : 'off');
-      chip.textContent = m.icon;
-      chip.title = `${m.name}${m.cash > 0 ? ' (+'+fmtCash(m.cash)+')' : ''} — ${m.desc}`;
-      medalRow.appendChild(chip);
+      addBadge(m.icon, `${m.name}${m.cash > 0 ? ' (+'+fmtCash(m.cash)+')' : ''} — ${m.desc}`, got ? 'on' : 'off');
     }
 
     // ── daily deal resolution (defensive: dailyDealFor may be absent) ──
@@ -570,11 +482,12 @@ export function createStore(deps){
     // so physics/hud/results (which already read state.perm.speedo etc.)
     // needed no changes.
     //
-    // Layout: cards are grouped into tier rows by upgDepth() so the grid
-    // reads as an actual tree, and an absolutely-positioned SVG underlay
-    // draws a connector from each card up to every visible prerequisite
-    // card (two-parent nodes get two lines). Geometry comes from real DOM
-    // rects, recomputed by the ResizeObserver/resize hooks above.
+    // Layout: one flat grid, one icon cell per level of each visible
+    // upgrade, grouped so an upgrade's levels sit contiguously (in
+    // UPGRADES' own root→leaf order — no depth tiers, no connector lines).
+    // Only the level right after the owned count is buyable; later levels
+    // show their price greyed out so the player can plan ahead. Name,
+    // per-level effect, and price only ever show in the hover tooltip.
     shopGrid.innerHTML = '';
     function isOwned(id){
       const u = UPGRADES.find(x => x.id === id);
@@ -585,127 +498,62 @@ export function createStore(deps){
     const missingRequires = u => (u.requires || []).filter(id => !isOwned(id));
     const upgAvail = UPGRADES.filter(u =>
       state.best.dist >= (u.unlock||0) && ownedLevel(u) < u.max && missingRequires(u).length === 0);
+    const capOut = capRemaining() <= 0;
 
-    const svgNS = 'http://www.w3.org/2000/svg';
-    const treeSvg = document.createElementNS(svgNS, 'svg');
-    treeSvg.setAttribute('class', 'tree-svg');
-    treeSvg.setAttribute('preserveAspectRatio', 'none');
-    shopGrid.appendChild(treeSvg);
-
-    const cardEls = {};
-    const tiers = new Map();
     for(const u of upgAvail){
-      const d = upgDepth(u.id);
-      if(!tiers.has(d)) tiers.set(d, []);
-      tiers.get(d).push(u);
-    }
-
-    for(const depth of [...tiers.keys()].sort((a,b)=>a-b)){
-      const row = document.createElement('div');
-      row.className = 'tree-tier';
-      for(const u of tiers.get(depth)){
       const lvl = ownedLevel(u);
-      const baseCost = upgCost(u);
+      const levels = u.oneTime ? 1 : u.max;
+      const group = document.createElement('div');
+      group.className = 'upg-group';
 
-      // Apply daily deal discount if this upgrade matches today's deal.
-      const isDailyDeal = todaysDeal && todaysDeal.id === u.id;
-      const dealDiscount = isDailyDeal && typeof todaysDeal.discount === 'number'
-        ? clamp(todaysDeal.discount, 0, 0.9)
-        : 0;
-      const cost = isDailyDeal ? Math.max(1, Math.round(baseCost * (1 - dealDiscount))) : baseCost;
-      const capOut = capRemaining() <= 0;
+      for(let i=0; i<levels; i++){
+        const owned = i < lvl;
+        const isNext = i === lvl;
+        const rawCost = u.oneTime ? u.base : Math.round(u.base * Math.pow(u.mul, i));
 
-      const affordable = !capOut && state.money >= cost;
-      const card = document.createElement('div');
-      card.className = 'upg' + (affordable ? ' affordable' : '') + (isDailyDeal ? ' daily-deal' : '');
+        // Daily deal discount only ever applies to the next buyable level.
+        const isDailyDeal = isNext && todaysDeal && todaysDeal.id === u.id;
+        const dealDiscount = isDailyDeal && typeof todaysDeal.discount === 'number'
+          ? clamp(todaysDeal.discount, 0, 0.9) : 0;
+        const cost = isDailyDeal ? Math.max(1, Math.round(rawCost * (1 - dealDiscount))) : rawCost;
+        const affordable = isNext && !capOut && state.money >= cost;
 
-      const pips = Array.from({length:u.max}, (_,i)=>`<div class="pip${i<lvl?' on':''}"></div>`).join('');
+        const cell = document.createElement('div');
+        cell.className = 'lvl-icon' +
+          (owned ? ' owned' : isNext ? ' next' : ' locked') +
+          (affordable ? ' affordable' : '') + (isDailyDeal ? ' daily-deal' : '');
 
-      // Daily deal badge styling injected inline so it works without a CSS edit.
-      const dealBadgeHTML = isDailyDeal
-        ? `<div style="font-size:9px;font-weight:bold;color:#ff0;background:#500;padding:1px 5px;border-radius:2px;display:inline-block;">
-             ⚡ DAILY DEAL −${Math.round(dealDiscount*100)}%
-           </div>`
-        : '';
-      const capBadgeHTML = capOut
-        ? `<div style="font-size:9px;font-weight:bold;color:#ff8a8a;background:#3a1010;padding:1px 5px;border-radius:2px;display:inline-block;" title="Fish Co. is out of deliveries for today — fly again, or buy Cargo Crate for a bigger allowance.">
-             \u{1F4E6} OUT OF DELIVERIES
-           </div>`
-        : '';
+        const effect = u.oneTime ? u.desc : u.val(i + 1);
+        const statusLine = owned ? 'owned'
+          : isNext && capOut ? 'no deliveries left today'
+          : isDailyDeal ? `${fmtCash(cost)} (deal, was ${fmtCash(rawCost)})`
+          : fmtCash(cost);
+        const tipLabel = levels > 1 ? `${u.name} · Lv.${i+1}` : u.name;
 
-      // Hover/focus reveal — the card itself stays minimal (icon, name,
-      // pips, buy button); the single next-step payoff only shows in this
-      // overlay. Leveled nodes preview the NEXT level's stat; one-time
-      // nodes have no ladder (val() is just installed/not), so their
-      // overlay explains what the gear does instead.
-      const nextHTML = u.oneTime
-        ? `<b>one-time gear</b>${u.desc}`
-        : `<b>next level</b>${u.val(lvl + 1)}`;
+        cell.innerHTML = `
+          <div class="lvl-art">${UPG_ICONS[u.id] || `<span style="font-size:28px">${u.icon}</span>`}</div>
+          <div class="lvl-price">${owned ? '✓' : fmtCash(cost)}</div>
+          <div class="lvl-tip"><b>${tipLabel}</b>${effect}<br>${statusLine}</div>`;
 
-      card.innerHTML = `
-        <div class="upg-art">${UPG_ICONS[u.id] || `<span style="font-size:40px">${u.icon}</span>`}</div>
-        <div class="upg-name">${u.name}</div>
-        ${dealBadgeHTML}${capBadgeHTML}
-        <div class="pips">${pips}</div>
-        <button ${(capOut || state.money<cost)?'disabled':''}>${isDailyDeal ? `Deal — ${fmtCash(cost)}` : `Buy — ${fmtCash(cost)}`}${isDailyDeal && baseCost !== cost ? ` <s style="color:var(--muted);font-size:9px">${fmtCash(baseCost)}</s>` : ''}</button>
-        <div class="upg-next">${nextHTML}</div>`;
-      card.querySelector('button').addEventListener('click', () => {
-        if(state.money < cost || capRemaining() <= 0) return;
-        state.money -= cost;
-        if(u.oneTime) state.perm[u.id] = true;
-        else state.lvl[u.id]++;
-        registerPurchase();
-        econLog?.logBuy({ name: u.name, id: u.id, cost, lvl: u.oneTime ? 'owned' : state.lvl[u.id] });
-        SFX.buy();
-        save();
-        renderShop();
-        recompute();   // live-preview taller ramp behind the shop
-      });
-      row.appendChild(card);
-      cardEls[u.id] = card;
-      }
-      shopGrid.appendChild(row);
-    }
-
-    // ── connector pass ──
-    // Bezier from the bottom-center of each visible prerequisite card to
-    // the top-center of its dependent. A parent that's maxed out (and thus
-    // no longer rendered) simply contributes no line. Lines to a currently
-    // affordable card glow dusk-gold; the rest stay glacial blue.
-    function drawConnectors(){
-      while(treeSvg.firstChild) treeSvg.removeChild(treeSvg.firstChild);
-      const g = shopGrid.getBoundingClientRect();
-      if(g.width < 2 || g.height < 2) return;   // shop hidden — retry on observe
-      treeSvg.setAttribute('viewBox', `0 0 ${g.width} ${g.height}`);
-      for(const u of upgAvail){
-        const card = cardEls[u.id];
-        for(const rid of (u.requires || [])){
-          const parent = cardEls[rid];
-          if(!parent) continue;
-          const cr = card.getBoundingClientRect();
-          const pr = parent.getBoundingClientRect();
-          const x1 = pr.left + pr.width/2 - g.left, y1 = pr.bottom - g.top - 1;
-          const x2 = cr.left + cr.width/2 - g.left, y2 = cr.top - g.top + 1;
-          const bend = Math.max(12, (y2 - y1) * 0.5);
-          const gold = card.classList.contains('affordable');
-          const path = document.createElementNS(svgNS, 'path');
-          path.setAttribute('d', `M ${x1} ${y1} C ${x1} ${y1+bend}, ${x2} ${y2-bend}, ${x2} ${y2}`);
-          path.setAttribute('fill', 'none');
-          path.setAttribute('stroke', gold ? 'rgba(255,200,87,0.6)' : 'rgba(148,164,224,0.45)');
-          path.setAttribute('stroke-width', '2');
-          treeSvg.appendChild(path);
-          for(const [cx, cy] of [[x1, y1], [x2, y2]]){
-            const dot = document.createElementNS(svgNS, 'circle');
-            dot.setAttribute('cx', cx); dot.setAttribute('cy', cy);
-            dot.setAttribute('r', '2.6');
-            dot.setAttribute('fill', gold ? 'rgba(255,200,87,0.85)' : 'rgba(148,164,224,0.65)');
-            treeSvg.appendChild(dot);
-          }
+        if(isNext){
+          cell.tabIndex = 0;
+          cell.addEventListener('click', () => {
+            if(state.money < cost || capRemaining() <= 0) return;
+            state.money -= cost;
+            if(u.oneTime) state.perm[u.id] = true;
+            else state.lvl[u.id]++;
+            registerPurchase();
+            econLog?.logBuy({ name: u.name, id: u.id, cost, lvl: u.oneTime ? 'owned' : state.lvl[u.id] });
+            SFX.buy();
+            save();
+            renderShop();
+            recompute();   // live-preview taller ramp behind the shop
+          });
         }
+        group.appendChild(cell);
       }
+      shopGrid.appendChild(group);
     }
-    redrawConnectors = drawConnectors;
-    requestAnimationFrame(drawConnectors);
   }
 
   return { renderShop, drawEditor };

--- a/pages/flightless.html
+++ b/pages/flightless.html
@@ -197,8 +197,9 @@
   }
   @media (max-width:700px){
     .shop-top{ padding:38px 0 0; }
-    .shop-grid{ grid-template-columns:repeat(13, minmax(46px,1fr)); gap:12px 6px; }
-    .lvl-icon{ width:42px; }
+    .shop-grid{ grid-template-columns:repeat(6, minmax(72px,1fr)); gap:16px 10px; }
+    .upg-node{ width:66px; }
+    .upg-node .node-art svg{ width:34px; height:34px; }
   }
   .shop-top .game-title{ margin:0; text-align:left; font-size:clamp(18px,2.6vw,28px); letter-spacing:2.5px; }
   .shop-top .subtitle{ margin:0; text-align:left; flex:1 1 auto; }
@@ -282,67 +283,76 @@
   .shop-panel[hidden]{ display:none; }
 
   /* ── upgrade tree ──
-     A real tree laid out on a CSS grid (TREE_LAYOUT in store.js): every
-     upgrade owns a dedicated row (lane), and each of its LEVELS is its own
-     grid cell/node placed one per column along that lane — level i sits
-     at column startCol+i, so a 12-level upgrade is a chain of 12
-     individual nodes, not one clustered card. An absolutely-positioned SVG
-     underlay (.tree-svg, built by store.js) draws two kinds of line: a
-     plain rail strung through one upgrade's own level-nodes (so its levels
-     read as one path), and a bezier from a prerequisite's level-1 node to
-     its dependent's level-1 node (the actual unlock point) — lanes are
-     ordered so those branch curves bend both up and down off the
-     wings/aero/rocket hub, not in one flat stack. Price sits under each
-     icon; name/effect only ever show on hover. */
+     A bog-standard branching upgrade tree on a CSS grid (TREE_LAYOUT in
+     store.js): one node per upgrade, the Ramp dead centre, branches
+     radiating outward in every direction — flight up, ground game down,
+     instruments left, economy right. Every node is always visible: locked
+     nodes (prerequisites unmet) render greyed with a 🔒, maxed nodes show
+     ✓ MAX, buyable ones show their next-level price. An absolutely-
+     positioned SVG underlay (.tree-svg) draws the dependency edges — solid
+     gold where the requirement is met, dim dashed where the route is still
+     locked, with an Lv.N badge on level-threshold edges. Icon + price +
+     level pips on the node; name/effect/requirements only on hover. */
   .shop-grid{
     position:relative; display:grid;
-    grid-template-columns:repeat(13, minmax(58px,1fr));
-    grid-auto-rows:min-content;
-    gap:14px 8px; padding:8px 2px 14px; margin-bottom:8px;
+    grid-template-columns:repeat(6, minmax(92px,1fr));
+    grid-auto-rows:1fr; gap:22px 16px;
+    padding:14px 6px 18px; margin-bottom:8px;
     overflow-x:auto;
   }
   .tree-svg{
     position:absolute; inset:0; width:100%; height:100%;
     z-index:0; pointer-events:none;
   }
-  .lvl-icon{
-    position:relative; z-index:1; width:50px; cursor:help;
+  .upg-node{
+    position:relative; z-index:1; justify-self:center; align-self:center;
+    width:78px; cursor:help;
     background:linear-gradient(165deg,var(--panel2) 0%,var(--panel) 100%);
-    border:1px solid var(--border); border-radius:10px;
-    padding:6px 4px 5px; display:flex; flex-direction:column; gap:3px;
+    border:1px solid var(--border); border-radius:12px;
+    padding:8px 6px 7px; display:flex; flex-direction:column; gap:4px;
     align-items:center; text-align:center;
-    box-shadow:0 3px 8px rgba(4,6,20,0.3), inset 0 1px 0 rgba(255,255,255,0.05);
+    box-shadow:0 3px 10px rgba(4,6,20,0.32), inset 0 1px 0 rgba(255,255,255,0.05);
     transition:transform 0.12s ease, border-color 0.12s ease, box-shadow 0.12s ease;
   }
-  .lvl-icon svg{ width:28px; height:28px; display:block; filter:drop-shadow(0 2px 3px rgba(0,0,0,0.35)); }
-  .lvl-icon .lvl-price{ font-size:10px; font-weight:700; color:var(--muted); }
-  .lvl-icon.owned{ opacity:0.55; }
-  .lvl-icon.owned .lvl-price{ color:var(--cash); }
-  .lvl-icon.locked{ filter:grayscale(0.7); opacity:0.4; cursor:default; }
-  .lvl-icon.next{ cursor:pointer; }
-  .lvl-icon.next:hover{
+  .upg-node .node-art svg{ width:40px; height:40px; display:block; filter:drop-shadow(0 2px 3px rgba(0,0,0,0.35)); }
+  .upg-node .node-art span{ line-height:40px; }
+  .upg-node .node-price{ font-size:11px; font-weight:800; color:var(--muted); letter-spacing:0.2px; }
+  .upg-node .node-price s{ font-size:9px; color:var(--muted); opacity:0.7; font-weight:600; }
+  .upg-node .node-price .pmax{ color:var(--cash); }
+  .upg-node .node-price .pnow{ color:var(--text); }
+  .upg-node .node-price .plock{ color:var(--muted); }
+  .upg-node .node-pips{ display:flex; flex-wrap:wrap; gap:3px; justify-content:center; max-width:70px; }
+  .upg-node .pip{ width:8px; height:5px; border-radius:2px; background:rgba(10,14,38,0.85); border:1px solid var(--border); }
+  .upg-node .pip.on{ background:var(--yellow); border-color:var(--yellow); box-shadow:0 0 4px rgba(255,200,87,0.5); }
+  /* node states */
+  .upg-node.locked{ filter:grayscale(0.85); opacity:0.42; cursor:help; }
+  .upg-node.maxed{ border-color:rgba(99,230,164,0.45); box-shadow:0 0 10px rgba(99,230,164,0.14), inset 0 1px 0 rgba(255,255,255,0.05); }
+  .upg-node.buyable{ cursor:pointer; }
+  .upg-node.buyable:hover{
     border-color:var(--border-strong); transform:translateY(-2px);
-    box-shadow:0 6px 14px rgba(4,6,20,0.4), inset 0 1px 0 rgba(255,255,255,0.07);
+    box-shadow:0 8px 18px rgba(4,6,20,0.42), inset 0 1px 0 rgba(255,255,255,0.07);
   }
-  .lvl-icon.next.affordable{ border-color:rgba(99,230,164,0.65); box-shadow:0 0 10px rgba(99,230,164,0.2), inset 0 1px 0 rgba(255,255,255,0.05); }
-  .lvl-icon.next.affordable .lvl-price{ color:#8ff0bb; }
-  .lvl-icon.next.daily-deal{ border-color:rgba(255,200,87,0.75); box-shadow:0 0 12px rgba(255,180,60,0.25), inset 0 1px 0 rgba(255,255,255,0.05); }
-  .lvl-icon.next.daily-deal .lvl-price{ color:#ffd88a; }
-  .lvl-icon.next:not(.affordable) .lvl-price{ color:var(--red); }
-  /* hover/focus tooltip — name + level effect + price, hidden by default */
-  .lvl-icon .lvl-tip{
-    position:absolute; left:50%; bottom:calc(100% + 6px); transform:translateX(-50%);
-    width:170px; z-index:5;
-    background:rgba(9,12,32,0.96); border:1px solid var(--border-strong);
-    border-radius:10px; padding:8px 9px;
-    font-size:10.5px; line-height:1.45; color:var(--text); text-align:left;
+  .upg-node.buyable.affordable{ border-color:rgba(99,230,164,0.7); box-shadow:0 0 13px rgba(99,230,164,0.24), inset 0 1px 0 rgba(255,255,255,0.05); }
+  .upg-node.buyable.affordable .node-price .pnow{ color:#8ff0bb; }
+  .upg-node.buyable.daily-deal{ border-color:rgba(255,200,87,0.78); box-shadow:0 0 14px rgba(255,180,60,0.28), inset 0 1px 0 rgba(255,255,255,0.05); }
+  .upg-node.buyable.daily-deal .node-price .pdeal{ color:#ffd88a; }
+  .upg-node.buyable:not(.affordable) .node-price .pnow{ color:#ff9a8a; }
+  /* hover/focus tooltip */
+  .upg-node .node-tip{
+    position:absolute; left:50%; bottom:calc(100% + 8px); transform:translateX(-50%);
+    width:184px; z-index:6;
+    background:rgba(9,12,32,0.97); border:1px solid var(--border-strong);
+    border-radius:11px; padding:9px 10px;
+    font-size:10.5px; line-height:1.5; color:var(--text); text-align:left;
     opacity:0; pointer-events:none; transition:opacity .12s ease;
-    box-shadow:0 8px 18px rgba(4,6,20,0.5);
+    box-shadow:0 8px 20px rgba(4,6,20,0.55);
   }
-  .lvl-icon .lvl-tip b{
-    display:block; font-size:10.5px; font-weight:800; color:#ffd88a; margin-bottom:2px;
-  }
-  .lvl-icon:hover .lvl-tip, .lvl-icon:focus-within .lvl-tip{ opacity:1; }
+  .upg-node .node-tip b{ display:block; font-size:12px; font-weight:800; color:#ffd88a; }
+  .upg-node .node-tip .tip-lvl{ display:block; font-size:9px; font-weight:700; letter-spacing:1px; text-transform:uppercase; color:var(--teal); margin-bottom:3px; }
+  .upg-node .node-tip .tip-effect{ display:block; }
+  .upg-node .node-tip .need{ display:block; margin-top:4px; color:#ff9a8a; font-weight:700; }
+  .upg-node .node-tip .tip-buy{ margin-top:5px; padding-top:5px; border-top:1px solid var(--border); color:#8ff0bb; font-weight:700; }
+  .upg-node:hover .node-tip, .upg-node:focus-within .node-tip{ opacity:1; }
 
   .goals{
     background:var(--glass); border:1px solid var(--border); border-radius:12px;
@@ -558,7 +568,7 @@
 
   @media (prefers-reduced-motion:reduce){
     .big-btn{ animation:none; }
-    .lvl-icon, .lvl-icon:hover{ transform:none; transition:none; }
+    .upg-node, .upg-node:hover{ transform:none; transition:none; }
     .popup{ animation-duration:0.6s; }
   }
 </style>

--- a/pages/flightless.html
+++ b/pages/flightless.html
@@ -197,9 +197,8 @@
   }
   @media (max-width:700px){
     .shop-top{ padding:38px 0 0; }
-    .shop-grid{ gap:14px 18px; }
-    .upg-group{ gap:4px; }
-    .lvl-icon{ width:48px; }
+    .shop-grid{ grid-template-columns:repeat(13, minmax(46px,1fr)); gap:12px 6px; }
+    .lvl-icon{ width:42px; }
   }
   .shop-top .game-title{ margin:0; text-align:left; font-size:clamp(18px,2.6vw,28px); letter-spacing:2.5px; }
   .shop-top .subtitle{ margin:0; text-align:left; flex:1 1 auto; }
@@ -283,18 +282,31 @@
   .shop-panel[hidden]{ display:none; }
 
   /* ── upgrade tree ──
-     A single flat grid of level icons: one cell per level of each unlocked
-     upgrade, grouped so an upgrade's levels sit contiguously. Price sits
-     under the icon; name/description/effect only ever show on hover. */
+     A real tree laid out on a CSS grid (TREE_LAYOUT in store.js): every
+     upgrade owns a dedicated row (lane), and each of its LEVELS is its own
+     grid cell/node placed one per column along that lane — level i sits
+     at column startCol+i, so a 12-level upgrade is a chain of 12
+     individual nodes, not one clustered card. An absolutely-positioned SVG
+     underlay (.tree-svg, built by store.js) draws two kinds of line: a
+     plain rail strung through one upgrade's own level-nodes (so its levels
+     read as one path), and a bezier from a prerequisite's level-1 node to
+     its dependent's level-1 node (the actual unlock point) — lanes are
+     ordered so those branch curves bend both up and down off the
+     wings/aero/rocket hub, not in one flat stack. Price sits under each
+     icon; name/effect only ever show on hover. */
   .shop-grid{
-    display:flex; flex-wrap:wrap; align-content:flex-start;
-    gap:18px 22px; padding:8px 2px 14px; margin-bottom:8px;
+    position:relative; display:grid;
+    grid-template-columns:repeat(13, minmax(58px,1fr));
+    grid-auto-rows:min-content;
+    gap:14px 8px; padding:8px 2px 14px; margin-bottom:8px;
+    overflow-x:auto;
   }
-  .upg-group{
-    display:flex; gap:5px; flex-wrap:wrap; align-items:flex-start;
+  .tree-svg{
+    position:absolute; inset:0; width:100%; height:100%;
+    z-index:0; pointer-events:none;
   }
   .lvl-icon{
-    position:relative; width:56px; flex:0 0 auto; cursor:help;
+    position:relative; z-index:1; width:50px; cursor:help;
     background:linear-gradient(165deg,var(--panel2) 0%,var(--panel) 100%);
     border:1px solid var(--border); border-radius:10px;
     padding:6px 4px 5px; display:flex; flex-direction:column; gap:3px;
@@ -302,7 +314,7 @@
     box-shadow:0 3px 8px rgba(4,6,20,0.3), inset 0 1px 0 rgba(255,255,255,0.05);
     transition:transform 0.12s ease, border-color 0.12s ease, box-shadow 0.12s ease;
   }
-  .lvl-icon svg{ width:32px; height:32px; display:block; filter:drop-shadow(0 2px 3px rgba(0,0,0,0.35)); }
+  .lvl-icon svg{ width:28px; height:28px; display:block; filter:drop-shadow(0 2px 3px rgba(0,0,0,0.35)); }
   .lvl-icon .lvl-price{ font-size:10px; font-weight:700; color:var(--muted); }
   .lvl-icon.owned{ opacity:0.55; }
   .lvl-icon.owned .lvl-price{ color:var(--cash); }

--- a/pages/flightless.html
+++ b/pages/flightless.html
@@ -197,9 +197,9 @@
   }
   @media (max-width:700px){
     .shop-top{ padding:38px 0 0; }
-    .shop-grid{ gap:26px; }
-    .tree-tier{ gap:10px; }
-    .upg{ width:134px; }
+    .shop-grid{ gap:14px 18px; }
+    .upg-group{ gap:4px; }
+    .lvl-icon{ width:48px; }
   }
   .shop-top .game-title{ margin:0; text-align:left; font-size:clamp(18px,2.6vw,28px); letter-spacing:2.5px; }
   .shop-top .subtitle{ margin:0; text-align:left; flex:1 1 auto; }
@@ -283,106 +283,90 @@
   .shop-panel[hidden]{ display:none; }
 
   /* ── upgrade tree ──
-     Cards render in tier rows (depth from the tree roots) with an SVG
-     underlay (.tree-svg, built by store.js) drawing prerequisite
-     connector lines between them. */
+     A single flat grid of level icons: one cell per level of each unlocked
+     upgrade, grouped so an upgrade's levels sit contiguously. Price sits
+     under the icon; name/description/effect only ever show on hover. */
   .shop-grid{
-    position:relative;
-    display:flex; flex-direction:column; gap:34px;
-    padding:8px 2px 14px; margin-bottom:8px;
+    display:flex; flex-wrap:wrap; align-content:flex-start;
+    gap:18px 22px; padding:8px 2px 14px; margin-bottom:8px;
   }
-  .tree-svg{
-    position:absolute; inset:0; width:100%; height:100%;
-    z-index:0; pointer-events:none;
+  .upg-group{
+    display:flex; gap:5px; flex-wrap:wrap; align-items:flex-start;
   }
-  .tree-tier{
-    position:relative; z-index:1;
-    display:flex; justify-content:center; gap:14px 16px; flex-wrap:wrap;
-  }
-  .upg{
-    position:relative; width:150px; flex:0 0 auto;
+  .lvl-icon{
+    position:relative; width:56px; flex:0 0 auto; cursor:help;
     background:linear-gradient(165deg,var(--panel2) 0%,var(--panel) 100%);
-    border:1px solid var(--border); border-radius:var(--radius);
-    padding:10px 10px 11px; display:flex; flex-direction:column; gap:6px;
+    border:1px solid var(--border); border-radius:10px;
+    padding:6px 4px 5px; display:flex; flex-direction:column; gap:3px;
     align-items:center; text-align:center;
-    box-shadow:0 4px 12px rgba(4,6,20,0.3), inset 0 1px 0 rgba(255,255,255,0.05);
-    transition:transform 0.15s ease, border-color 0.15s ease, box-shadow 0.15s ease;
+    box-shadow:0 3px 8px rgba(4,6,20,0.3), inset 0 1px 0 rgba(255,255,255,0.05);
+    transition:transform 0.12s ease, border-color 0.12s ease, box-shadow 0.12s ease;
   }
-  .upg:hover{
+  .lvl-icon svg{ width:32px; height:32px; display:block; filter:drop-shadow(0 2px 3px rgba(0,0,0,0.35)); }
+  .lvl-icon .lvl-price{ font-size:10px; font-weight:700; color:var(--muted); }
+  .lvl-icon.owned{ opacity:0.55; }
+  .lvl-icon.owned .lvl-price{ color:var(--cash); }
+  .lvl-icon.locked{ filter:grayscale(0.7); opacity:0.4; cursor:default; }
+  .lvl-icon.next{ cursor:pointer; }
+  .lvl-icon.next:hover{
     border-color:var(--border-strong); transform:translateY(-2px);
-    box-shadow:0 8px 20px rgba(4,6,20,0.4), inset 0 1px 0 rgba(255,255,255,0.07);
+    box-shadow:0 6px 14px rgba(4,6,20,0.4), inset 0 1px 0 rgba(255,255,255,0.07);
   }
-  .upg.affordable{ border-color:rgba(99,230,164,0.65); box-shadow:0 0 14px rgba(99,230,164,0.18), inset 0 1px 0 rgba(255,255,255,0.05); }
-  .upg.affordable:hover{ box-shadow:0 0 18px rgba(99,230,164,0.28), 0 8px 20px rgba(4,6,20,0.4); }
-  .upg.daily-deal{ border-color:rgba(255,200,87,0.7); box-shadow:0 0 16px rgba(255,180,60,0.22), inset 0 1px 0 rgba(255,255,255,0.05); }
-  .upg .upg-art{ display:flex; justify-content:center; align-items:center; }
-  .upg .upg-art svg{
-    width:58px; height:58px; display:block;
-    filter:drop-shadow(0 2px 4px rgba(0,0,0,0.35));
-  }
-  .upg .upg-name{ font-weight:800; color:#ffd88a; font-size:12px; letter-spacing:0.2px; }
-  /* next-level stat — hidden until the card is hovered or focused */
-  .upg .upg-next{
-    position:absolute; left:5px; right:5px; top:5px; z-index:3;
-    background:rgba(9,12,32,0.93); border:1px solid var(--border-strong);
+  .lvl-icon.next.affordable{ border-color:rgba(99,230,164,0.65); box-shadow:0 0 10px rgba(99,230,164,0.2), inset 0 1px 0 rgba(255,255,255,0.05); }
+  .lvl-icon.next.affordable .lvl-price{ color:#8ff0bb; }
+  .lvl-icon.next.daily-deal{ border-color:rgba(255,200,87,0.75); box-shadow:0 0 12px rgba(255,180,60,0.25), inset 0 1px 0 rgba(255,255,255,0.05); }
+  .lvl-icon.next.daily-deal .lvl-price{ color:#ffd88a; }
+  .lvl-icon.next:not(.affordable) .lvl-price{ color:var(--red); }
+  /* hover/focus tooltip — name + level effect + price, hidden by default */
+  .lvl-icon .lvl-tip{
+    position:absolute; left:50%; bottom:calc(100% + 6px); transform:translateX(-50%);
+    width:170px; z-index:5;
+    background:rgba(9,12,32,0.96); border:1px solid var(--border-strong);
     border-radius:10px; padding:8px 9px;
-    font-size:10.5px; line-height:1.45; color:var(--text);
-    opacity:0; pointer-events:none; transition:opacity .14s ease;
+    font-size:10.5px; line-height:1.45; color:var(--text); text-align:left;
+    opacity:0; pointer-events:none; transition:opacity .12s ease;
     box-shadow:0 8px 18px rgba(4,6,20,0.5);
   }
-  .upg .upg-next b{
-    display:block; font-size:8.5px; font-weight:800; letter-spacing:1.6px;
-    color:var(--teal); text-transform:uppercase; margin-bottom:2px;
+  .lvl-icon .lvl-tip b{
+    display:block; font-size:10.5px; font-weight:800; color:#ffd88a; margin-bottom:2px;
   }
-  .upg:hover .upg-next, .upg:focus-within .upg-next{ opacity:1; }
-  .upg .pips{ display:flex; gap:3px; flex-wrap:wrap; justify-content:center; }
-  .upg .pip{ width:10px; height:6px; border-radius:3px; background:rgba(10,14,38,0.8); border:1px solid var(--border); }
-  .upg .pip.on{ background:var(--yellow); border-color:var(--yellow); box-shadow:0 0 5px rgba(255,200,87,0.5); }
-  .upg button{
-    width:100%; margin-top:auto;
-    font-weight:800; font-size:12px; letter-spacing:0.3px;
-    background:var(--btn-grad); color:var(--btn-ink);
-    border:none; border-radius:10px; padding:6px 8px; cursor:pointer;
-    box-shadow:0 3px 0 var(--btn-lip);
-    transition:filter .12s ease, transform .06s ease, box-shadow .06s ease;
-  }
-  .upg button:hover:not(:disabled){ filter:brightness(1.08); }
-  .upg button:active:not(:disabled){ transform:translateY(2px); box-shadow:0 1px 0 var(--btn-lip); }
-  .upg button:disabled{
-    background:#2a3160; color:#7580b5; box-shadow:0 3px 0 #1b2150;
-    cursor:not-allowed;
-  }
-  /* the bonus-shop refund link (styled inline by JS as a text link) must not
-     inherit the chunky button treatment */
-  .upg .bonus-refund{ box-shadow:none !important; border-radius:0; }
-  .upg .locked-note{ font-size:10.5px; font-weight:700; color:var(--red); }
+  .lvl-icon:hover .lvl-tip, .lvl-icon:focus-within .lvl-tip{ opacity:1; }
 
-  .medal-row{ display:flex; flex-wrap:wrap; gap:6px; margin-bottom:8px; }
-  .medal{
-    font-size:18px; line-height:1; padding:8px; cursor:help;
+  .goals{
+    background:var(--glass); border:1px solid var(--border); border-radius:12px;
+    padding:8px 14px; margin:0; font-size:12px;
+    display:flex; align-items:flex-start; gap:12px; flex-wrap:wrap;
+  }
+  .goals h3{
+    margin:4px 0 0; color:var(--yellow); font-size:11px; font-weight:800;
+    text-transform:uppercase; letter-spacing:1.5px; white-space:nowrap;
+  }
+  /* ── achievements grid ──
+     Milestones, landmark bosses, daily contracts, and medals all render as
+     one flat icon grid — no text list. Completion state is on/off (plus a
+     transitional "next"/"partial" state); every detail (name, reward,
+     description, progress) lives in the hover tooltip only. */
+  .ach-grid{ display:flex; flex-wrap:wrap; gap:6px; flex:1 1 auto; }
+  .ach{
+    position:relative; font-size:18px; line-height:1; padding:8px; cursor:help;
     background:linear-gradient(165deg,var(--panel2),var(--panel));
     border:1px solid var(--border); border-radius:12px;
   }
-  .medal.on{
+  .ach.on{
     border-color:rgba(255,200,87,0.75);
     background:linear-gradient(165deg,#3a3564,var(--panel));
     box-shadow:0 0 10px rgba(255,190,80,0.28);
   }
-  .medal.off{ filter:grayscale(1); opacity:0.32; }
-
-  .goals{
-    background:var(--glass); border:1px solid var(--border); border-radius:12px;
-    padding:6px 14px; margin:0; font-size:12px;
-    display:flex; align-items:center; gap:12px;
+  .ach.off{ filter:grayscale(1); opacity:0.32; }
+  .ach.partial{ filter:grayscale(0.65); opacity:0.6; }
+  .ach.next{ opacity:0.9; border-color:rgba(255,216,138,0.55); }
+  .ach.contract{ border-style:dashed; opacity:0.75; }
+  .ach-pct{
+    position:absolute; right:-5px; bottom:-5px; min-width:18px; padding:1px 4px;
+    border-radius:999px; background:var(--cash); color:#053a1e;
+    font-size:9px; font-weight:800; text-align:center; line-height:14px;
+    border:1px solid var(--panel);
   }
-  .goals h3{
-    margin:0; color:var(--yellow); font-size:11px; font-weight:800;
-    text-transform:uppercase; letter-spacing:1.5px; white-space:nowrap;
-  }
-  .goals ul{ margin:0; padding:0; list-style:none; display:flex; flex-wrap:wrap; gap:3px 14px; }
-  .goals li{ color:var(--muted); white-space:nowrap; }
-  .goals li.done{ color:var(--cash); text-decoration:line-through; }
-  .goals li.next{ color:#ffd88a; font-weight:700; }
 
   .big-btn{
     display:block; margin:18px auto 0; padding:14px 60px;
@@ -562,7 +546,7 @@
 
   @media (prefers-reduced-motion:reduce){
     .big-btn{ animation:none; }
-    .upg, .upg:hover{ transform:none; transition:none; }
+    .lvl-icon, .lvl-icon:hover{ transform:none; transition:none; }
     .popup{ animation-duration:0.6s; }
   }
 </style>
@@ -625,9 +609,8 @@
       </div>
     </div>
     <div class="goals">
-      <h3>&#127937; Goals</h3>
-      <ul id="goal-list"></ul>
-      <div class="medal-row" id="medal-row"></div>
+      <h3>&#127942; Achievements</h3>
+      <div class="ach-grid" id="ach-grid"></div>
     </div>
     <div class="shop-scroll">
       <div class="shop-panel" id="panel-upgrades">


### PR DESCRIPTION
## Summary
Completely redesigns the in-game shop interface, replacing the tier-based upgrade card layout with a radial grid-based tree centered on the Ramp, and consolidating all achievement tracking (milestones, landmarks, contracts, medals) into a single icon-based grid instead of a text list.

## Key Changes

**Upgrade Tree Layout**
- Replaced depth-based tier rows with a hand-placed CSS grid layout (TREE_LAYOUT object)
- Ramp positioned at center (col:3, row:7) with branches radiating outward: flight tech spine upward, ground game downward, instruments leftward, economy rightward
- Every upgrade node always visible on screen (locked nodes greyed with 🔒, maxed nodes show ✓ MAX)
- Connector lines now curve appropriately for horizontal/vertical/diagonal edges with proper bezier bending
- Added level-threshold badges on edges where a prerequisite requires a specific level (e.g., "L3")
- Implemented scroll centering to focus viewport on the Ramp root on first layout

**Prerequisite System Enhancement**
- Extended `requires` format to support level thresholds: `'id'` (level ≥1) or `{ id, lvl }` (level ≥ lvl)
- Updated all upgrade definitions to use new format (e.g., Speedometer now requires Ramp Lv.3, Fuel Regen requires Fuel Lv.4 + Wings Lv.3)
- Normalized requirement checking with `reqId()` and `reqLvl()` helpers

**Achievements Panel Redesign**
- Consolidated milestones, landmarks, daily contracts, and medals into single `ach-grid` (achievements grid)
- Replaced text-based goals list with icon-only badges showing completion state (on/off/partial/next)
- Added percentage indicators for landmark damage progress
- All detail text (name, reward, description, progress) moved to hover tooltips only
- Unified styling for all achievement types with consistent on/off/partial/next/contract states

**Node Interaction & Tooltips**
- Upgraded nodes now show icon, price, and level pips on the card itself
- Hover tooltip displays name, level, effect description, unmet requirements, and buy action
- Keyboard support added (Enter/Space to purchase)
- Improved visual feedback for affordable/daily-deal/locked/maxed states

**Removed Code**
- Deleted `upgDepth()` tree depth calculation (no longer needed for tier-based layout)
- Removed ramp preset buttons (moved to separate implementation or removed entirely)
- Removed `upgCost()` from dependencies (cost calculation now inline)

## Implementation Details

- Grid uses CSS `grid-template-columns: repeat(6, minmax(92px,1fr))` for responsive layout
- SVG connector lines drawn with adaptive bezier curves based on dominant axis (horizontal vs vertical)
- Connector styling: solid gold for met requirements, dim dashed for locked routes
- ResizeObserver handles dynamic layout changes and connector redraw
- Scroll centering uses `getBoundingClientRect()` to calculate viewport offset on first render
- Mobile breakpoint (max-width: 700px) adjusts grid to 6 columns with smaller nodes (66px)

https://claude.ai/code/session_019SYRTotZZ5ggNS6x2Z8UGd