### PR TITLE
Remove Gridworks and Unyellow from interactive projects list

### DIFF
--- a/index.html
+++ b/index.html
@@ -128,10 +128,6 @@
         <h2>Interactive Projects</h2>
         <ul>
           <li>
-            <a href="pages/gridworks.html">Gridworks</a>
-            <p class="project-summary">A Factorio-inspired automation game where every sprite is 5×5 pixels. Mine ore, build belts and machines, research tech, launch a rocket.</p>
-          </li>
-          <li>
             <a href="pages/flightless.html">Flightless</a>
             <p class="project-summary">A Learn to Fly-inspired launch game. Hurl a penguin off a ramp, earn cash, buy upgrades, learn to fly.</p>
           </li>
@@ -146,10 +142,6 @@
           <li>
             <a href="pages/cartoguesser.html">CartoGuesser</a>
             <p class="project-summary">A cyberpunk themed map guessing game built with Leaflet for interactive geography challenges.</p>
-          </li>
-          <li>
-            <a href="pages/unyellow.html">Unyellow</a>
-            <p class="project-summary">Upload photos with yellow tint and automatically correct the colors with adjustable RGB sliders.</p>
           </li>
           <li>
             <a href="pages/wallfacer.html">Wallfacer</a>


### PR DESCRIPTION
## Summary
This PR removes two projects from the Interactive Projects section of the portfolio: Gridworks and Unyellow.

## Changes
- Removed Gridworks project entry (Factorio-inspired automation game)
- Removed Unyellow project entry (photo color correction tool)

These projects are no longer featured in the main interactive projects list on the portfolio homepage.

https://claude.ai/code/session_018QESJ9NCaXHp7Mb1YhWiBz